### PR TITLE
Declare encoding (fixes #1)

### DIFF
--- a/adresse/app.py
+++ b/adresse/app.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+from __future__ import unicode_literals
 import os
 
 from flask import Flask, render_template

--- a/adresse/constants.py
+++ b/adresse/constants.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 DEPARTEMENTS = {
     "01": "Ain",
     "02": "Aisne",


### PR DESCRIPTION
Here is a fix for #1.
Explicit encoding declaration is needed for Python 2.7.