### PR TITLE
Spécifie que le résultat du géocodage est au format CSV

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,7 @@ workflows:
 
       - deploy:
           requires:
+            - lint
             - build
           filters:
             branches:

--- a/lib/geocode/many.js
+++ b/lib/geocode/many.js
@@ -52,7 +52,9 @@ export default async function geocodeMany(inputFile, encoding, columns) {
     return obj
   })
 
-  return new Blob([Papa.unparse(processedResponse, {delimiter: DELIMITER})])
+  return new Blob([
+    Papa.unparse(processedResponse, {delimiter: DELIMITER})
+  ], {type: 'text/csv; charset=utf-8'})
 }
 
 function parse(str, options) {


### PR DESCRIPTION
Cela permet d'indiquer au navigateur quoi faire avec le fichier produit.
Permet notamment l'ouverture dans Excel.