### PR TITLE
Améliore l'affichage sur mobile du composant en-tête

### DIFF
--- a/components/head.js
+++ b/components/head.js
@@ -44,6 +44,17 @@ const Head = ({children, title, icon}) => (
         font-style: italic;
         margin-bottom: 0;
       }
+
+      @media (max-width: 480px) {
+        .row {
+          flex-direction: column;
+          padding: 40px 20px;
+        }
+
+        .text {
+          padding-left: 0;
+        }
+      }
       `}</style>
   </div>
 )


### PR DESCRIPTION
### Avant
<img width="429" alt="capture d ecran 2018-07-04 a 15 51 44" src="https://user-images.githubusercontent.com/7040549/42280915-5f6ef2ce-7fa2-11e8-8914-12be89ffbe54.png">

### Après
<img width="425" alt="capture d ecran 2018-07-04 a 15 51 54" src="https://user-images.githubusercontent.com/7040549/42280916-5f8e42b4-7fa2-11e8-8676-b18d156ff58d.png">
