### PR TITLE
Corrige l'affichage des champs inconnus

### DIFF
--- a/components/bases-locales/validator/report/index.js
+++ b/components/bases-locales/validator/report/index.js
@@ -17,22 +17,45 @@ class Report extends React.Component {
             <div>
               <h3>Validation de la structure du fichier</h3>
               <div className='items'>
-                <CsvMeta name='Encodage des caractères' value={fileValidation.encoding.value} isValid={fileValidation.encoding.isValid} />
-                <CsvMeta name='Délimiteur' value={fileValidation.delimiter.localName} isValid={fileValidation.delimiter.isValid} />
-                <CsvMeta name='Nombre de lignes' value={parseMeta.rowsCount} isValid />
-                <CsvMeta name='Séparateur de ligne' value={fileValidation.linebreak.value} isValid={fileValidation.linebreak.isValid} />
+                <CsvMeta
+                  name='Encodage des caractères'
+                  value={fileValidation.encoding.value}
+                  isValid={fileValidation.encoding.isValid}
+                />
+                <CsvMeta
+                  name='Délimiteur'
+                  value={fileValidation.delimiter.localName}
+                  isValid={fileValidation.delimiter.isValid}
+                />
+                <CsvMeta
+                  name='Nombre de lignes'
+                  value={parseMeta.rowsCount} isValid
+                />
+                <CsvMeta
+                  name='Séparateur de ligne'
+                  value={fileValidation.linebreak.value}
+                  isValid={fileValidation.linebreak.isValid}
+                />
               </div>
             </div>}
         </div>
 
         <div className='container'>
           <h3>Validation des champs</h3>
-          <Rows rows={rowsWithErrors} rowsErrorsCount={rowsErrorsCount} />
+          <Rows
+            rows={rowsWithErrors}
+            rowsErrorsCount={rowsErrorsCount}
+            unknownFields={unknownFields}
+          />
         </div>
 
         <div className='container'>
           <h3>Champs existants</h3>
-          <Fields found={knownFields} unknown={unknownFields} alias={aliasedFields} />
+          <Fields
+            found={knownFields}
+            unknown={unknownFields}
+            alias={aliasedFields}
+          />
         </div>
 
         <style jsx>{`

--- a/components/bases-locales/validator/report/line-value.js
+++ b/components/bases-locales/validator/report/line-value.js
@@ -4,15 +4,6 @@ import PropTypes from 'prop-types'
 import theme from '../../../../styles/theme'
 
 class LineValue extends React.Component {
-  constructor(props) {
-    super(props)
-
-    const errors = props.value.errors || []
-    this.state = {
-      error: errors.length > 0
-    }
-  }
-
   handleMouseOver = () => {
     const {value, handleHover} = this.props
 
@@ -26,17 +17,19 @@ class LineValue extends React.Component {
   }
 
   render() {
-    const {value} = this.props
-    const {error} = this.state
+    const {value, unknownField} = this.props
+    const {rawValue, errors} = value
 
     return (
-      <Fragment key={value.rawValue}>
-        {error ? (
+      <Fragment key={rawValue}>
+        {errors && errors.length > 0 ? (
           <td className='error' onMouseOver={this.handleMouseOver} onMouseOut={this.handleMouseOut}>
-            {value.rawValue}
+            {rawValue}
           </td>
         ) : (
-          <td className='valid'>{value.rawValue}</td>
+          <td className={`${unknownField ? 'unknown' : 'valid'}`}>
+            {rawValue}
+          </td>
         )}
 
         <style jsx>{`
@@ -57,6 +50,10 @@ class LineValue extends React.Component {
           td.valid {
             background: ${theme.successBg};
           }
+
+          td.unknown {
+            background: ${theme.backgroundGrey};
+          }
         `}</style>
       </Fragment>
     )
@@ -64,7 +61,11 @@ class LineValue extends React.Component {
 }
 
 LineValue.propTypes = {
-  value: PropTypes.object.isRequired,
+  value: PropTypes.shape({
+    rawValue: PropTypes.string,
+    errors: PropTypes.array
+  }).isRequired,
+  unknownField: PropTypes.bool.isRequired,
   handleHover: PropTypes.func.isRequired
 }
 

--- a/components/bases-locales/validator/report/line.js
+++ b/components/bases-locales/validator/report/line.js
@@ -5,7 +5,7 @@ import theme from '../../../../styles/theme'
 
 import LineValue from './line-value'
 
-const Line = ({line, onHover}) => {
+const Line = ({line, unknownFields, onHover}) => {
   return (
     <div className='container'>
       <table>
@@ -17,7 +17,12 @@ const Line = ({line, onHover}) => {
         <tbody>
           <tr>
             {Object.keys(line).map(key => !key.startsWith('_') &&
-              <LineValue key={`td-${key}`} value={line[key]} handleHover={onHover} />
+              <LineValue
+                key={`td-${key}`}
+                value={line[key]}
+                unknownField={unknownFields.includes(key)}
+                handleHover={onHover}
+              />
             )}
           </tr>
         </tbody>
@@ -49,6 +54,7 @@ const Line = ({line, onHover}) => {
 
 Line.propTypes = {
   line: PropTypes.object.isRequired,
+  unknownFields: PropTypes.array.isRequired,
   onHover: PropTypes.func.isRequired
 }
 

--- a/components/bases-locales/validator/report/row.js
+++ b/components/bases-locales/validator/report/row.js
@@ -7,13 +7,14 @@ import Line from './line'
 import RowErrors from './row-errors'
 
 class Row extends React.Component {
-  static propTypes = {
-    row: PropTypes.object.isRequired
-  }
-
   state = {
     showErr: false,
     field: null
+  }
+
+  static propTypes = {
+    row: PropTypes.object.isRequired,
+    unknownFields: PropTypes.array.isRequired
   }
 
   handleError = () => {
@@ -29,7 +30,7 @@ class Row extends React.Component {
 
   render() {
     const {showErr, field} = this.state
-    const {row} = this.props
+    const {row, unknownFields} = this.props
     const errCount = row._errors.length
 
     return (
@@ -53,8 +54,15 @@ class Row extends React.Component {
 
         {showErr &&
           <div className='container'>
-            <Line line={row} onHover={this.handleField} />
-            {row._errors.length > 0 && <RowErrors errors={row._errors} field={field} />}
+            <Line
+              line={row}
+              unknownFields={unknownFields}
+              onHover={this.handleField}
+            />
+
+            {row._errors.length > 0 && (
+              <RowErrors errors={row._errors} field={field} />
+            )}
           </div>}
 
         <style jsx>{`

--- a/components/bases-locales/validator/report/rows.js
+++ b/components/bases-locales/validator/report/rows.js
@@ -7,15 +7,28 @@ import theme from '../../../../styles/theme'
 import Row from './row'
 
 class Rows extends React.Component {
+  static propTypes = {
+    rows: PropTypes.array.isRequired,
+    rowsErrorsCount: PropTypes.number.isRequired,
+    unknownFields: PropTypes.array
+  }
+
+  static defaultProps = {
+    unknownFields: []
+  }
+
   render() {
-    const {rows, rowsErrorsCount} = this.props
+    const {rows, rowsErrorsCount, unknownFields} = this.props
+
     return (
       <div>
         {rowsErrorsCount === 0 && <h3>Aucune anomalie trouvée <span className='valid'><FaCheck /></span></h3>}
         {rowsErrorsCount === 1 && <h3>{rowsErrorsCount} anomalie trouvée</h3>}
         {rowsErrorsCount > 1 && <h3>{rowsErrorsCount} anomalies trouvées</h3>}
         <div>
-          {rows.map(row => <Row key={`row-${row._line}`} row={row} />)}
+          {rows.map(row => (
+            <Row key={`row-${row._line}`} row={row} unknownFields={unknownFields} />
+          ))}
         </div>
         <style jsx>{`
             .valid {
@@ -25,11 +38,6 @@ class Rows extends React.Component {
       </div>
     )
   }
-}
-
-Rows.propTypes = {
-  rows: PropTypes.array.isRequired,
-  rowsErrorsCount: PropTypes.number.isRequired
 }
 
 export default Rows

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "heroku-postbuild": "next build"
   },
   "dependencies": {
-    "@etalab/bal": "^0.9.0",
+    "@etalab/bal": "^0.10.0",
     "@etalab/project-legal": "^0.3.2",
     "@mapbox/mapbox-gl-draw": "^1.0.9",
     "@turf/bbox": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -884,10 +884,10 @@
     lodash "^4.17.5"
     to-fast-properties "^2.0.0"
 
-"@etalab/bal@^0.9.0":
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@etalab/bal/-/bal-0.9.0.tgz#b1b6b7ca8039f80b5e3d3891790c9ae4f55aa411"
-  integrity sha512-sdN+Kx6BvAg2M84Ui+EpsTg2u3CbNiSjjH2CQksZH5V3XICCMqju2ece7Waaf8nVropV5iKSYH3B1Zw6oJxfSA==
+"@etalab/bal@^0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@etalab/bal/-/bal-0.10.0.tgz#a21f6d625036d7cd8cdd81472773b6776d9fba5e"
+  integrity sha512-6tE46a5vPUE3bQ0h9WcqlzSjV/NDih0lG0Jn0/meQXtNh/VBL5t7GSRmn1Ok8n7VoxwbSuC7NAIqQPcm08Scpw==
   dependencies:
     blob-to-buffer "^1.2.8"
     date-fns "^1.29.0"


### PR DESCRIPTION
Affiche la valeur `rawValue` des champs inconnus. Ces champs n'étant ni "valide" ni "erronés", ils sont désormais afficher en gris afin d'être plus neutre.

Fix #165 Test du validateur BAL