### PR TITLE
Correctif listing des BAL

### DIFF
--- a/components/bases-locales/bases-adresse-locales/dataset/communes-preview.js
+++ b/components/bases-locales/bases-adresse-locales/dataset/communes-preview.js
@@ -11,7 +11,7 @@ class CommunesPreview extends React.Component {
   static propTypes = {
     dataset: PropTypes.shape({
       id: PropTypes.string.isRequired,
-      lastUpdate: PropTypes.string.isRequired,
+      lastUpdate: PropTypes.string,
       licenseLabel: PropTypes.string.isRequired,
       status: PropTypes.string.isRequired,
       valid: PropTypes.bool,
@@ -49,7 +49,7 @@ class CommunesPreview extends React.Component {
     const {communes, source} = summary
 
     return (
-      <Preview geojson={contoursToGeoJson(communes)}>
+      <Preview geojson={communes.length > 0 ? contoursToGeoJson(communes) : null}>
         <Meta
           infos={this.infos}
           report={{id, status, valid, error}}

--- a/components/bases-locales/bases-adresse-locales/dataset/preview/index.js
+++ b/components/bases-locales/bases-adresse-locales/dataset/preview/index.js
@@ -5,8 +5,12 @@ import Map from './map'
 
 class Preview extends React.Component {
   static propTypes = {
-    geojson: PropTypes.object.isRequired,
+    geojson: PropTypes.object,
     children: PropTypes.node.isRequired
+  }
+
+  static defaultProps = {
+    geojson: null
   }
 
   render() {


### PR DESCRIPTION
Correctif rapide pour ne pas afficher d'erreur 500 quand le résultat d'analyse est incomplet.