### PR TITLE
[BAL] Traite les résultats du validateur selon leur gravité

### DIFF
--- a/components/bases-locales/validator/index.js
+++ b/components/bases-locales/validator/index.js
@@ -133,7 +133,10 @@ class BALValidator extends React.Component {
 
     this.setState({inProgress: true})
     validate(file)
-      .then(report => this.setState({report, inProgress: false}))
+      .then(report => {
+        report.rowsWithIssuesCount = report.rowsWithIssues.length
+        this.setState({report, inProgress: false})
+      })
       .then(() => {
         if (this.state.url) {
           this.pushEncodedUrl()

--- a/components/bases-locales/validator/report/index.js
+++ b/components/bases-locales/validator/report/index.js
@@ -9,7 +9,7 @@ import Rows from './rows'
 
 class Report extends React.Component {
   render() {
-    const {knownFields, unknownFields, aliasedFields, fileValidation, rowsWithErrors, parseMeta, rowsErrorsCount} = this.props.report
+    const {knownFields, unknownFields, aliasedFields, fileValidation, rowsWithIssues, parseMeta, rowsWithIssuesCount} = this.props.report
     return (
       <div>
         <div className='container'>
@@ -43,8 +43,8 @@ class Report extends React.Component {
         <div className='container'>
           <h3>Validation des champs</h3>
           <Rows
-            rows={rowsWithErrors}
-            rowsErrorsCount={rowsErrorsCount}
+            rows={rowsWithIssues}
+            rowsWithIssuesCount={rowsWithIssuesCount}
             unknownFields={unknownFields}
           />
         </div>
@@ -82,9 +82,9 @@ Report.propTypes = {
     knownFields: PropTypes.array.isRequired,
     unknownFields: PropTypes.array.isRequired,
     aliasedFields: PropTypes.object.isRequired,
-    rowsWithErrors: PropTypes.array.isRequired,
+    rowsWithIssues: PropTypes.array.isRequired,
     parseMeta: PropTypes.object.isRequired,
-    rowsErrorsCount: PropTypes.number.isRequired,
+    rowsWithIssuesCount: PropTypes.number.isRequired,
     fileValidation: PropTypes.shape({
       encoding: PropTypes.object.isRequired,
       delimiter: PropTypes.object.isRequired,

--- a/components/bases-locales/validator/report/line-value.js
+++ b/components/bases-locales/validator/report/line-value.js
@@ -18,12 +18,16 @@ class LineValue extends React.Component {
 
   render() {
     const {value, unknownField} = this.props
-    const {rawValue, errors} = value
+    const {rawValue, errors, warnings} = value
+    const hasErrors = errors && errors.length > 0
+    const hasWarnings = warnings && warnings.length > 0
+    const hasIssues = hasErrors || hasWarnings
+    const issuesType = hasErrors ? 'error' : 'warning'
 
     return (
       <Fragment key={rawValue}>
-        {errors && errors.length > 0 ? (
-          <td className='error' onMouseOver={this.handleMouseOver} onMouseOut={this.handleMouseOut}>
+        {hasIssues ? (
+          <td className={issuesType} onMouseOver={this.handleMouseOver} onMouseOut={this.handleMouseOut}>
             {rawValue}
           </td>
         ) : (
@@ -41,9 +45,19 @@ class LineValue extends React.Component {
             background: ${theme.errorBg};
           }
 
+          td.warning {
+            background: ${theme.warningBg};
+          }
+
           td.error:hover {
             cursor: pointer;
             background: ${theme.errorBorder};
+            color: ${theme.colors.white};
+          }
+
+          td.warning:hover {
+            cursor: pointer;
+            background: ${theme.warningBorder};
             color: ${theme.colors.white};
           }
 

--- a/components/bases-locales/validator/report/row-issues.js
+++ b/components/bases-locales/validator/report/row-issues.js
@@ -3,12 +3,16 @@ import PropTypes from 'prop-types'
 
 import theme from '../../../../styles/theme'
 
-const RowErrors = ({errors, field}) => (
+const RowErrors = ({errors, warnings, field}) => (
   <div className='abnormalities'>
-    <h3>Anomalie{errors.length > 1 ? 's' : ''} :</h3>
+    <h3>Anomalie{(errors.length + warnings.length) > 1 ? 's' : ''} :</h3>
     <div className='error-list'>
+      {warnings.map(err => (
+        <div key={err} className={`issue warning ${field && (field.warnings.includes(err)) ? 'select' : ''}`}>
+          {err}
+        </div>))}
       {errors.map(err => (
-        <div key={err} className={`field ${field && field.errors.includes(err) ? 'select' : ''}`}>
+        <div key={err} className={`issue error ${field && (field.warnings.includes(err)) ? 'select' : ''}`}>
           {err}
         </div>))}
     </div>
@@ -21,16 +25,30 @@ const RowErrors = ({errors, field}) => (
         margin: 1em 0;
       }
 
-      .field {
+      .issue {
         padding: 0.5em;
         margin: 0.5em 0;
         border-radius: 3px;
+      }
+
+      .error {
         background: ${theme.errorBg};
       }
 
-      .field.select {
-        background: ${theme.errorBorder};
+      .warning {
+        background: ${theme.warningBg};
+      }
+
+      .issue.select {
         color: ${theme.colors.white};
+      }
+
+      .error.select {
+        background: ${theme.errorBorder};
+      }
+
+      .warning.select {
+        background: ${theme.warningBorder};
       }
       `}</style>
   </div>
@@ -38,6 +56,7 @@ const RowErrors = ({errors, field}) => (
 
 RowErrors.propTypes = {
   errors: PropTypes.array.isRequired,
+  warnings: PropTypes.array.isRequired,
   field: PropTypes.object
 }
 

--- a/components/bases-locales/validator/report/row.js
+++ b/components/bases-locales/validator/report/row.js
@@ -4,11 +4,11 @@ import PropTypes from 'prop-types'
 import theme from '../../../../styles/theme'
 
 import Line from './line'
-import RowErrors from './row-errors'
+import RowIssues from './row-issues'
 
 class Row extends React.Component {
   state = {
-    showErr: false,
+    showIssues: false,
     field: null
   }
 
@@ -19,7 +19,7 @@ class Row extends React.Component {
 
   handleError = () => {
     this.setState(state => ({
-      showErr: !state.showErr,
+      showIssues: !state.showIssues,
       field: null
     }))
   }
@@ -29,9 +29,9 @@ class Row extends React.Component {
   }
 
   render() {
-    const {showErr, field} = this.state
+    const {showIssues, field} = this.state
     const {row, unknownFields} = this.props
-    const errCount = row._errors.length
+    const issuesCount = row._errors.length + row._warnings.length
 
     return (
       <div>
@@ -40,19 +40,19 @@ class Row extends React.Component {
             <b>Ligne {row._line}</b> {row.cle_interop.rawValue && `[${row.cle_interop.rawValue}]`}
           </div>
           <div>
-            {errCount === 1 ? (
+            {issuesCount === 1 ? (
               <span className='error' onClick={this.handleError}>
-                {showErr ? 'Masquer' : 'Afficher'} l’anomalie
+                {showIssues ? 'Masquer' : 'Afficher'} l’anomalie
               </span>
             ) : (
               <span className='error' onClick={this.handleError}>
-                {showErr ? 'Masquer' : 'Afficher'} les {errCount} anomalies
+                {showIssues ? 'Masquer' : 'Afficher'} les {issuesCount} anomalies
               </span>
             )}
           </div>
         </div>
 
-        {showErr &&
+        {showIssues &&
           <div className='container'>
             <Line
               line={row}
@@ -60,8 +60,8 @@ class Row extends React.Component {
               onHover={this.handleField}
             />
 
-            {row._errors.length > 0 && (
-              <RowErrors errors={row._errors} field={field} />
+            {issuesCount > 0 && (
+              <RowIssues errors={row._errors} warnings={row._warnings} field={field} />
             )}
           </div>}
 

--- a/components/bases-locales/validator/report/rows.js
+++ b/components/bases-locales/validator/report/rows.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import {take} from 'lodash'
 import FaCheck from 'react-icons/lib/fa/check'
 
 import theme from '../../../../styles/theme'
@@ -19,6 +20,7 @@ class Rows extends React.Component {
 
   render() {
     const {rows, rowsWithIssuesCount, unknownFields} = this.props
+    const rowsToDisplay = take(rows, 1000)
 
     return (
       <div>
@@ -30,7 +32,7 @@ class Rows extends React.Component {
           null
         }
         <div>
-          {rows.map(row => (
+          {rowsToDisplay.map(row => (
             <Row key={`row-${row._line}`} row={row} unknownFields={unknownFields} />
           ))}
         </div>

--- a/components/bases-locales/validator/report/rows.js
+++ b/components/bases-locales/validator/report/rows.js
@@ -25,6 +25,10 @@ class Rows extends React.Component {
         {rowsWithIssuesCount === 0 && <h3>Aucune ligne avec anomalies trouvée <span className='valid'><FaCheck /></span></h3>}
         {rowsWithIssuesCount === 1 && <h3>{rowsWithIssuesCount} ligne avec anomalies trouvée</h3>}
         {rowsWithIssuesCount > 1 && <h3>{rowsWithIssuesCount} lignes avec anomalies trouvées</h3>}
+        {rowsWithIssuesCount > 1000 ?
+          <p>Seules les 1000 premières lignes avec anomalies sont affichées ici.</p> :
+          null
+        }
         <div>
           {rows.map(row => (
             <Row key={`row-${row._line}`} row={row} unknownFields={unknownFields} />

--- a/components/bases-locales/validator/report/rows.js
+++ b/components/bases-locales/validator/report/rows.js
@@ -9,7 +9,7 @@ import Row from './row'
 class Rows extends React.Component {
   static propTypes = {
     rows: PropTypes.array.isRequired,
-    rowsErrorsCount: PropTypes.number.isRequired,
+    rowsWithIssuesCount: PropTypes.number.isRequired,
     unknownFields: PropTypes.array
   }
 
@@ -18,13 +18,13 @@ class Rows extends React.Component {
   }
 
   render() {
-    const {rows, rowsErrorsCount, unknownFields} = this.props
+    const {rows, rowsWithIssuesCount, unknownFields} = this.props
 
     return (
       <div>
-        {rowsErrorsCount === 0 && <h3>Aucune anomalie trouvée <span className='valid'><FaCheck /></span></h3>}
-        {rowsErrorsCount === 1 && <h3>{rowsErrorsCount} anomalie trouvée</h3>}
-        {rowsErrorsCount > 1 && <h3>{rowsErrorsCount} anomalies trouvées</h3>}
+        {rowsWithIssuesCount === 0 && <h3>Aucune ligne avec anomalies trouvée <span className='valid'><FaCheck /></span></h3>}
+        {rowsWithIssuesCount === 1 && <h3>{rowsWithIssuesCount} ligne avec anomalies trouvée</h3>}
+        {rowsWithIssuesCount > 1 && <h3>{rowsWithIssuesCount} lignes avec anomalies trouvées</h3>}
         <div>
           {rows.map(row => (
             <Row key={`row-${row._line}`} row={row} unknownFields={unknownFields} />

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "heroku-postbuild": "next build"
   },
   "dependencies": {
-    "@etalab/bal": "^0.10.0",
+    "@etalab/bal": "^0.11.1",
     "@etalab/project-legal": "^0.3.2",
     "@mapbox/mapbox-gl-draw": "^1.0.9",
     "@turf/bbox": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -805,17 +805,18 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@etalab/bal@^0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@etalab/bal/-/bal-0.10.0.tgz#a21f6d625036d7cd8cdd81472773b6776d9fba5e"
+"@etalab/bal@^0.11.1":
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/@etalab/bal/-/bal-0.11.1.tgz#aabaa9bcac3c2fe93c1d5b22815c77fac457a0d8"
+  integrity sha512-Wm4mHHpgpeEoFOJFtWQOhw+yxYua1lwziNMrWV8D2Da9THcDEs8utbQ6Njjn4vj8pJm7oK82lk59dnbQbW6Xjg==
   dependencies:
     blob-to-buffer "^1.2.8"
     date-fns "^1.29.0"
-    debug "^3.1.0"
+    debug "^4.1.0"
     jschardet-french "^0.0.1"
-    lodash "^4.17.10"
-    papaparse "^4.5.0"
-    yargs "^12.0.1"
+    lodash "^4.17.11"
+    papaparse "^4.6.1"
+    yargs "^12.0.2"
 
 "@etalab/project-legal@^0.3.2":
   version "0.3.2"
@@ -2647,7 +2648,7 @@ debug@3.1.0, debug@^3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^4.0.1:
+debug@^4.0.1, debug@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.0.tgz#373687bffa678b38b1cd91f861b63850035ddc87"
   integrity sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==
@@ -5523,6 +5524,11 @@ lodash@^4.17.10:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
+lodash@^4.17.11:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+
 lodash@^4.17.5:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
@@ -6503,9 +6509,10 @@ papaparse@^4.3.6:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-4.3.6.tgz#9566eda0ecab13afcb740a62381c699f486cb145"
 
-papaparse@^4.5.0:
+papaparse@^4.6.1:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-4.6.1.tgz#7b3c5bdf4f0fd12374e2d37f987e9d74a1834ca8"
+  integrity sha512-X9Ws5tnEQKRCZRfoojX3KvRZbLY1BbL0wqSHF3CKGmxD8Zr4E0WaipUuFweffkCN8RSQzHKhb/F+ATYdNcz1rg==
 
 parallel-transform@^1.1.0:
   version "1.1.0"
@@ -9190,9 +9197,10 @@ yargs@^11.0.0:
     y18n "^3.2.1"
     yargs-parser "^9.0.2"
 
-yargs@^12.0.1:
+yargs@^12.0.2:
   version "12.0.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.2.tgz#fe58234369392af33ecbef53819171eff0f5aadc"
+  integrity sha512-e7SkEx6N6SIZ5c5H22RTZae61qtn3PYUE8JYbBFlK9sYmh3DMQ6E5ygtaG/2BW0JZi4WGgTR2IV5ChqlqrDGVQ==
   dependencies:
     cliui "^4.0.0"
     decamelize "^2.0.0"


### PR DESCRIPTION
Sépare en "erreurs" et "avertissements".
Dans les deux cas cela fait perdre la conformité, mais les avertissements n'empêchent pas le processing des données.

Pour tester il faut faire tourner sa propre instance d'API BAL (`master`) en local, et définir la variable `API_BAL_URL`