### PR TITLE
Correction de redirection vers /editeur

### DIFF
--- a/pages/bases-locales/editeur.js
+++ b/pages/bases-locales/editeur.js
@@ -62,7 +62,7 @@ class EditorPage extends React.Component {
         }
       }
 
-      res.redirect('/bases-locales/editor')
+      res.redirect('/bases-locales/editeur')
     }
 
     return {


### PR DESCRIPTION
Une ancienne redirection n'a pas était renommer est provoquée une `404`.