### PR TITLE
Résume les erreurs et avertissements du validateur

### DIFF
--- a/components/bases-locales/validator/report/index.js
+++ b/components/bases-locales/validator/report/index.js
@@ -42,21 +42,21 @@ class Report extends React.Component {
         </div>
 
         <div className='container'>
+          <h3>Champs existants</h3>
+          <Fields
+            found={knownFields}
+            unknown={unknownFields}
+            alias={aliasedFields}
+          />
+        </div>
+
+        <div className='container'>
           <h3>Validation des champs</h3>
           <Rows
             rows={rowsWithIssues}
             issuesSummary={issuesSummary}
             rowsWithIssuesCount={rowsWithIssuesCount}
             unknownFields={unknownFields}
-          />
-        </div>
-
-        <div className='container'>
-          <h3>Champs existants</h3>
-          <Fields
-            found={knownFields}
-            unknown={unknownFields}
-            alias={aliasedFields}
           />
         </div>
 

--- a/components/bases-locales/validator/report/index.js
+++ b/components/bases-locales/validator/report/index.js
@@ -51,7 +51,7 @@ class Report extends React.Component {
         </div>
 
         <div className='container'>
-          <h3>Validation des champs</h3>
+          <h3>Validation des données</h3>
           <Rows
             rows={rowsWithIssues}
             issuesSummary={issuesSummary}

--- a/components/bases-locales/validator/report/index.js
+++ b/components/bases-locales/validator/report/index.js
@@ -9,7 +9,8 @@ import Rows from './rows'
 
 class Report extends React.Component {
   render() {
-    const {knownFields, unknownFields, aliasedFields, fileValidation, rowsWithIssues, parseMeta, rowsWithIssuesCount} = this.props.report
+    const {knownFields, unknownFields, aliasedFields, fileValidation, rowsWithIssues, issuesSummary, parseMeta, rowsWithIssuesCount} = this.props.report
+
     return (
       <div>
         <div className='container'>
@@ -44,6 +45,7 @@ class Report extends React.Component {
           <h3>Validation des champs</h3>
           <Rows
             rows={rowsWithIssues}
+            issuesSummary={issuesSummary}
             rowsWithIssuesCount={rowsWithIssuesCount}
             unknownFields={unknownFields}
           />
@@ -83,6 +85,7 @@ Report.propTypes = {
     unknownFields: PropTypes.array.isRequired,
     aliasedFields: PropTypes.object.isRequired,
     rowsWithIssues: PropTypes.array.isRequired,
+    issuesSummary: PropTypes.object.isRequired,
     parseMeta: PropTypes.object.isRequired,
     rowsWithIssuesCount: PropTypes.number.isRequired,
     fileValidation: PropTypes.shape({

--- a/components/bases-locales/validator/report/issue-rows.js
+++ b/components/bases-locales/validator/report/issue-rows.js
@@ -27,18 +27,18 @@ class IssueRows extends React.Component {
 
   render() {
     const {issue, rows, type, selected} = this.props
-    const warningRows = issue.rows.length
+    const issuesRows = issue.rows.length
 
     return (
       <div className='issue' onClick={this.handleClick}>
         <div>
           <b>{
-            warningRows === rows.length ?
+            issuesRows === rows.length ?
               'Toutes les lignes' :
-              warningRows === 1 ?
+              issuesRows === 1 ?
                 `La ligne ${issue.rows[0]}` :
-                `${warningRows} lignes`
-          }</b> {warningRows === 1 ? 'comporte' : 'comportent'} l’avertissement :
+                `${issuesRows} lignes`
+          }</b> {issuesRows === 1 ? 'comporte' : 'comportent'} l’anomalie :
 
           <span className='colored'> {issue.message}</span>
 

--- a/components/bases-locales/validator/report/issue-rows.js
+++ b/components/bases-locales/validator/report/issue-rows.js
@@ -1,0 +1,70 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import FaEye from 'react-icons/lib/fa/eye'
+
+import theme from '../../../../styles/theme'
+
+class IssueRows extends React.Component {
+  static propTypes = {
+    issue: PropTypes.shape({
+      message: PropTypes.string.isRequired,
+      rows: PropTypes.array.isRequired
+    }).isRequired,
+    rows: PropTypes.array.isRequired,
+    type: PropTypes.oneOf(['error', 'warning']).isRequired,
+    selected: PropTypes.bool,
+    onClick: PropTypes.func.isRequired
+  }
+
+  static defaultProps = {
+    selected: false
+  }
+
+  handleClick = () => {
+    const {issue, type, onClick} = this.props
+    onClick(issue, type)
+  }
+
+  render() {
+    const {issue, rows, type, selected} = this.props
+    const warningRows = issue.rows.length
+
+    return (
+      <div className='issue' onClick={this.handleClick}>
+        <div>
+          <b>{
+            warningRows === rows.length ?
+              'Toutes les lignes' :
+              warningRows === 1 ?
+                `La ligne ${issue.rows[0]}` :
+                `${warningRows} lignes`
+          }</b> {warningRows === 1 ? 'comporte' : 'comportent'} l’avertissement :
+
+          <span className='colored'> {issue.message}</span>
+
+          {selected && (
+            <span className='eye'><FaEye /></span>
+          )}
+        </div>
+
+        <style jsx>{`
+            .colored {
+              color: ${type === 'error' ? theme.errorBorder : theme.warningBorder};
+            }
+
+            .issue:hover {
+              cursor: pointer;
+              text-decoration: underline;
+            }
+
+            .eye {
+              margin-left: 1em;
+              font-size: 20px;
+            }
+        `}</style>
+      </div>
+    )
+  }
+}
+
+export default IssueRows

--- a/components/bases-locales/validator/report/row.js
+++ b/components/bases-locales/validator/report/row.js
@@ -7,14 +7,22 @@ import Line from './line'
 import RowIssues from './row-issues'
 
 class Row extends React.Component {
-  state = {
-    showIssues: false,
-    field: null
+  constructor(props) {
+    super(props)
+    this.state = {
+      showIssues: props.forceShowIssues,
+      field: null
+    }
   }
 
   static propTypes = {
     row: PropTypes.object.isRequired,
-    unknownFields: PropTypes.array.isRequired
+    unknownFields: PropTypes.array.isRequired,
+    forceShowIssues: PropTypes.bool
+  }
+
+  static defaultProps = {
+    forceShowIssues: false
   }
 
   handleError = () => {
@@ -30,7 +38,7 @@ class Row extends React.Component {
 
   render() {
     const {showIssues, field} = this.state
-    const {row, unknownFields} = this.props
+    const {row, unknownFields, forceShowIssues} = this.props
     const issuesCount = row._errors.length + row._warnings.length
 
     return (
@@ -60,7 +68,7 @@ class Row extends React.Component {
               onHover={this.handleField}
             />
 
-            {issuesCount > 0 && (
+            {(issuesCount > 0 || forceShowIssues) && (
               <RowIssues errors={row._errors} warnings={row._warnings} field={field} />
             )}
           </div>}

--- a/components/bases-locales/validator/report/rows.js
+++ b/components/bases-locales/validator/report/rows.js
@@ -1,15 +1,15 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import {take} from 'lodash'
 import FaCheck from 'react-icons/lib/fa/check'
 
 import theme from '../../../../styles/theme'
 
-import Row from './row'
+import Summary from './summary'
 
 class Rows extends React.Component {
   static propTypes = {
     rows: PropTypes.array.isRequired,
+    issuesSummary: PropTypes.object.isRequired,
     rowsWithIssuesCount: PropTypes.number.isRequired,
     unknownFields: PropTypes.array
   }
@@ -19,28 +19,33 @@ class Rows extends React.Component {
   }
 
   render() {
-    const {rows, rowsWithIssuesCount, unknownFields} = this.props
-    const rowsToDisplay = take(rows, 1000)
+    const {rows, issuesSummary, rowsWithIssuesCount, unknownFields} = this.props
 
     return (
       <div>
-        {rowsWithIssuesCount === 0 && <h3>Aucune ligne avec anomalies trouvée <span className='valid'><FaCheck /></span></h3>}
-        {rowsWithIssuesCount === 1 && <h3>{rowsWithIssuesCount} ligne avec anomalies trouvée</h3>}
-        {rowsWithIssuesCount > 1 && <h3>{rowsWithIssuesCount} lignes avec anomalies trouvées</h3>}
-        {rowsWithIssuesCount > 1000 ?
-          <p>Seules les 1000 premières lignes avec anomalies sont affichées ici.</p> :
-          null
-        }
-        <div>
-          {rowsToDisplay.map(row => (
-            <Row key={`row-${row._line}`} row={row} unknownFields={unknownFields} />
-          ))}
-        </div>
+        {rowsWithIssuesCount === 0 ? (
+          <h3>Aucune ligne avec anomalies trouvée <span className='valid'><FaCheck /></span></h3>
+        ) : (
+          <>
+            {rowsWithIssuesCount > 1 ? (
+              <h3>{rowsWithIssuesCount} lignes avec anomalies trouvées</h3>
+            ) : (
+              <h3>{rowsWithIssuesCount} ligne avec anomalies trouvée</h3>
+            )}
+
+            <Summary
+              rows={rows}
+              issuesSummary={issuesSummary}
+              unknownFields={unknownFields}
+            />
+          </>
+        )}
+
         <style jsx>{`
-            .valid {
-              color: ${theme.successBorder};
-            }
-            `}</style>
+          .valid {
+            color: ${theme.successBorder};
+          }
+        `}</style>
       </div>
     )
   }

--- a/components/bases-locales/validator/report/summary.js
+++ b/components/bases-locales/validator/report/summary.js
@@ -66,7 +66,7 @@ class Rows extends React.Component {
         {errors.length > 0 && (
           <>
             <h4>
-              Erreur{errors.count > 1 ? 's' : ''}
+              Erreur{errors.length > 1 ? 's' : ''}
               <div className='icon error'><FaClose /></div>
             </h4>
             <div className='list'>
@@ -87,7 +87,7 @@ class Rows extends React.Component {
         {warnings.length > 0 && (
           <>
             <h4>
-              Avertissement{warnings.count > 1 ? 's' : ''}
+              Avertissement{warnings.length > 1 ? 's' : ''}
               <div className='icon warning'><FaExclamationTriangle /></div>
             </h4>
 

--- a/components/bases-locales/validator/report/summary.js
+++ b/components/bases-locales/validator/report/summary.js
@@ -1,0 +1,167 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import {take, sortBy} from 'lodash'
+import FaExclamationTriangle from 'react-icons/lib/fa/exclamation-triangle'
+import FaClose from 'react-icons/lib/fa/close'
+
+import theme from '../../../../styles/theme'
+
+import Notification from '../../../notification'
+
+import Row from './row'
+import IssueRows from './issue-rows'
+
+const ROWS_LIMIT = 100
+
+class Rows extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      selectedIssue: null,
+      rowsToDisplay: []
+    }
+  }
+
+  static propTypes = {
+    rows: PropTypes.array.isRequired,
+    issuesSummary: PropTypes.shape({
+      errors: PropTypes.array.isRequired,
+      warnings: PropTypes.array.isRequired
+    }).isRequired,
+    unknownFields: PropTypes.array
+  }
+
+  static defaultProps = {
+    unknownFields: []
+  }
+
+  selectIssue = selectedIssue => {
+    const {rows} = this.props
+
+    if (selectedIssue === this.state.selectedIssue) {
+      this.setState({
+        selectedIssue: null,
+        rowsToDisplay: []
+      })
+    } else {
+      const filteredRows = rows.filter(row => selectedIssue.rows.includes(row._line))
+      this.setState({
+        selectedIssue,
+        rowsToDisplay: take(filteredRows, ROWS_LIMIT)
+      })
+    }
+  }
+
+  render() {
+    const {selectedIssue, rowsToDisplay} = this.state
+    const {rows, issuesSummary, unknownFields} = this.props
+    const {errors, warnings} = issuesSummary
+    const sortedErrors = sortBy(errors, error => error.rows.length)
+    const sortedWarnings = sortBy(warnings, warning => warning.rows.length)
+
+    return (
+      <div>
+        <h3>Résumé</h3>
+
+        {errors.length > 0 && (
+          <>
+            <h4>
+              Erreur{errors.count > 1 ? 's' : ''}
+              <div className='icon error'><FaClose /></div>
+            </h4>
+            <div className='list'>
+              {sortedErrors.map(error => (
+                <IssueRows
+                  key={error.message}
+                  issue={error}
+                  rows={rows}
+                  type='error'
+                  selected={error === selectedIssue}
+                  onClick={this.selectIssue}
+                />
+              ))}
+            </div>
+          </>
+        )}
+
+        {warnings.length > 0 && (
+          <>
+            <h4>
+              Avertissement{warnings.count > 1 ? 's' : ''}
+              <div className='icon warning'><FaExclamationTriangle /></div>
+            </h4>
+
+            <div className='list'>
+              {sortedWarnings.map(warning => (
+                <IssueRows
+                  key={warning.message}
+                  issue={warning}
+                  rows={rows}
+                  type='warning'
+                  selected={warning === selectedIssue}
+                  onClick={this.selectIssue}
+                />
+              ))}
+            </div>
+          </>
+        )}
+
+        {selectedIssue && (
+          <div className='issues-list'>
+            <h3>Ligne{selectedIssue.rows.length > 1 ? 's' : ''} avec l’anomalie :</h3>
+            <h4>{selectedIssue.message}</h4>
+
+            {selectedIssue.rows.length > ROWS_LIMIT && (
+              <Notification type='info'>
+                Seules les {ROWS_LIMIT} premières lignes avec anomalies sont affichées ici
+              </Notification>
+            )}
+
+            {rowsToDisplay.map(row => (
+              <Row
+                key={`row-${row._line}`}
+                row={row}
+                unknownFields={unknownFields}
+                forceShowIssues={rowsToDisplay.length === 1}
+              />
+            ))}
+          </div>
+        )}
+
+        <style jsx>{`
+            .error {
+              color: ${theme.errorBorder};
+            }
+
+            .warning {
+              color: ${theme.warningBorder};
+            }
+
+            h4 {
+              display: flex;
+              align-items: center;
+            }
+
+            .list {
+              display: grid;
+              grid-row-gap: 0.5em;
+            }
+
+            .issues-list {
+              padding: 1em;
+              margin: 1em 0;
+              box-shadow: 0 1px 4px ${theme.boxShadow};;
+            }
+
+            .icon {
+              margin-left: 0.5em;
+              padding-bottom: 0.1em;
+            }
+            `}</style>
+      </div>
+    )
+  }
+}
+
+export default Rows
+

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "heroku-postbuild": "next build"
   },
   "dependencies": {
-    "@etalab/bal": "^0.12.0",
+    "@etalab/bal": "^0.13.1",
     "@etalab/project-legal": "^0.3.2",
     "@mapbox/mapbox-gl-draw": "^1.0.9",
     "@turf/bbox": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -805,10 +805,10 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@etalab/bal@^0.12.0":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@etalab/bal/-/bal-0.12.0.tgz#7fb2ecd04f4894c15b643022c881475019115b8e"
-  integrity sha512-MKlTY5c3PBB0wcaV3x239FGSOQhq9wnqyDNA5y7HKlcAYRsrCPQLP2kB2Q/DCnkBmmh4nrDBmszTe7JcUB79hA==
+"@etalab/bal@^0.13.1":
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/@etalab/bal/-/bal-0.13.1.tgz#be1e1336ce97fb99514dfa6f763c401629fc05ec"
+  integrity sha512-yllFTXYaG60v4g315GV6fbCvIX3r8pZSvsVRygrbkn7uQSE/Vc/EIBuNjFbpELUco5sHHldo5efvB+H/uaM+PQ==
   dependencies:
     blob-to-buffer "^1.2.8"
     date-fns "^1.29.0"


### PR DESCRIPTION
Ajoute un résumé des erreurs et avertissements du validateur.

Ce résumé a pour objectif de ne pas afficher une liste interminable de lignes comportant des anomalies car bien souvent il s'agit d'erreurs structurelle.

### Fonctionnalités
- Sépare les erreurs des avertissements
- Groupe les lignes par erreur/avertissement
- Indique le nombre de lignes concernées par l’erreur/avertissement
- Affiche en un clique les ou la ligne concerné

![capture d ecran 2018-11-21 a 17 28 32](https://user-images.githubusercontent.com/7040549/48854745-ecf15280-edb2-11e8-8180-27d09ba0647c.png)


Fix #195 Résumer les erreurs structurelles du validateur