### PR TITLE
Corrige affichage du nom de la BAL

### DIFF
--- a/components/bases-locales/bases-adresse-locales/bal-report.js
+++ b/components/bases-locales/bases-adresse-locales/bal-report.js
@@ -9,10 +9,10 @@ import Header from './dataset/header'
 
 class BalReport extends React.Component {
   render() {
-    const {report, organization} = this.props
+    const {report, organization, title} = this.props
     return (
       <Section>
-        <Header name={organization.name} logo={organization.logo} />
+        <Header name={title} logo={organization.logo} />
         <Report report={report} />
       </Section>
     )
@@ -24,7 +24,8 @@ BalReport.propTypes = {
     name: PropTypes.string.isRequired,
     logo: PropTypes.string.isRequired
   }).isRequired,
-  report: PropTypes.object.isRequired
+  report: PropTypes.object.isRequired,
+  title: PropTypes.string.isRequired
 }
 
 export default BalReport

--- a/pages/bases-locales/datasets/dataset/report.js
+++ b/pages/bases-locales/datasets/dataset/report.js
@@ -16,7 +16,7 @@ class ReportPage extends React.Component {
 
     return (
       <Page title={dataset.title} description={description}>
-        <BalReport report={report} organization={dataset.organization} />
+        <BalReport report={report} title={dataset.title} organization={dataset.organization} />
       </Page>
     )
   }


### PR DESCRIPTION
Sur la page du rapport d'erreur, c'est le nom du producteur qui est affiché, et non le nom de la BAL.