### PR TITLE
Correction de la couleur de numéro

### DIFF
--- a/lib/geojson.js
+++ b/lib/geojson.js
@@ -105,7 +105,7 @@ export function communeNumerosToGeoJson(commune) {
               status: getStatus(numero),
               voieStatus: getStatus(voie),
               lastUpdate: positions[0].dateMAJ,
-              color: randomColor({luminosity: 'dark'})
+              color: randomColor({luminosity: 'dark', seed: voie.codeVoie})
             }
           })
         }


### PR DESCRIPTION
La couleur des numéros dépend du code de la voie à laquelle ils appartiennent.

### Avant
<img width="1216" alt="capture d ecran 2019-01-31 a 15 01 17" src="https://user-images.githubusercontent.com/7040549/52059186-65218480-2569-11e9-89b4-de74c4ef9239.png">

### Après
<img width="1103" alt="capture d ecran 2019-01-31 a 15 02 16" src="https://user-images.githubusercontent.com/7040549/52059185-6488ee00-2569-11e9-8675-f498e366b5e4.png">

