### PR TITLE
Amélioration du sélecteur de commune

### DIFF
--- a/components/bases-locales/editor/edit-bal/init-base.js
+++ b/components/bases-locales/editor/edit-bal/init-base.js
@@ -91,6 +91,7 @@ class InitBase extends React.Component {
     return (
       <div>
         <h3>Ajoutez autant de communes que vous souhaitez</h3>
+        <p><em>Il est possible de préciser le code département lorsque la commune a beaucoup d’homonymes. Exemple : Saint-Just 18</em></p>
         <SearchCommune handleSelect={this.addCommune} />
 
         {communes.length > 0 &&

--- a/components/bases-locales/editor/edit-bal/search-communes.js
+++ b/components/bases-locales/editor/edit-bal/search-communes.js
@@ -67,7 +67,7 @@ class SearchCommune extends React.Component {
     this.waitingFor = reqId
     const codeDepFilter = codeDep ? `&codeDepartement=${codeDep}` : ''
     const q = codeDep ? input.split(' ').filter(t => !isCodeDepNaive(t)).join(' ') : input
-    const url = `https://geo.api.gouv.fr/communes?nom=${q}${codeDepFilter}&fields=departement,contour&limit=8`
+    const url = `https://geo.api.gouv.fr/communes?nom=${encodeURIComponent(q)}${codeDepFilter}&fields=departement,contour&limit=8`
 
     try {
       const response = await _get(url)

--- a/components/bases-locales/editor/edit-bal/search-communes.js
+++ b/components/bases-locales/editor/edit-bal/search-communes.js
@@ -9,6 +9,14 @@ import RenderCommune from '../../../search-input/render-commune'
 import SearchInput from '../../../search-input'
 import Notification from '../../../notification'
 
+function isCodeDepNaive(token) {
+  if (['2A', '2B'].includes(token)) {
+    return true
+  }
+
+  return token.match(/^\d{2,3}$/)
+}
+
 class SearchCommune extends React.Component {
   static propTypes = {
     handleSelect: PropTypes.func.isRequired,
@@ -54,9 +62,12 @@ class SearchCommune extends React.Component {
   }
 
   async handleSearch(input) {
+    const codeDep = input.split(' ').find(isCodeDepNaive)
     const reqId = uniqueId('req_')
     this.waitingFor = reqId
-    const url = `https://geo.api.gouv.fr/communes?nom=${input}&fields=departement,contour&limit=5`
+    const codeDepFilter = codeDep ? `&codeDepartement=${codeDep}` : ''
+    const q = codeDep ? input.split(' ').filter(t => !isCodeDepNaive(t)).join(' ') : input
+    const url = `https://geo.api.gouv.fr/communes?nom=${q}${codeDepFilter}&fields=departement,contour&limit=5`
 
     try {
       const response = await _get(url)

--- a/components/bases-locales/editor/edit-bal/search-communes.js
+++ b/components/bases-locales/editor/edit-bal/search-communes.js
@@ -43,7 +43,7 @@ class SearchCommune extends React.Component {
   handleChange = input => {
     this.setState(() => {
       if (input) {
-        if (input.length < 5) {
+        if (input.length < 8) {
           this.handleSearchThrottled(input)
         } else {
           this.handleSearchDebounced(input)
@@ -67,7 +67,7 @@ class SearchCommune extends React.Component {
     this.waitingFor = reqId
     const codeDepFilter = codeDep ? `&codeDepartement=${codeDep}` : ''
     const q = codeDep ? input.split(' ').filter(t => !isCodeDepNaive(t)).join(' ') : input
-    const url = `https://geo.api.gouv.fr/communes?nom=${q}${codeDepFilter}&fields=departement,contour&limit=5`
+    const url = `https://geo.api.gouv.fr/communes?nom=${q}${codeDepFilter}&fields=departement,contour&limit=8`
 
     try {
       const response = await _get(url)

--- a/components/bases-locales/editor/edit-bal/search-communes.js
+++ b/components/bases-locales/editor/edit-bal/search-communes.js
@@ -43,7 +43,7 @@ class SearchCommune extends React.Component {
   handleChange = input => {
     this.setState(() => {
       if (input) {
-        if (input.length < 8) {
+        if (input.length < 5) {
           this.handleSearchThrottled(input)
         } else {
           this.handleSearchDebounced(input)


### PR DESCRIPTION
Jusqu'à maintenant il pouvait être impossible de sélectionner une commune avec de nombreux homonyme.

Exemple ici je cherche à sélectionner Saint-Just, dans le département du Cher :
<img width="753" alt="capture d ecran 2019-02-06 a 22 16 30" src="https://user-images.githubusercontent.com/1231232/52374263-1d18cb00-2a5d-11e9-9a92-6dc114368d61.png">

Cette PR augmente le nombre de résultats potentiels à 8 (au lieu de 5) et permet de préciser le code du département.

Exemple avec 8 résultats :

<img width="747" alt="capture d ecran 2019-02-06 a 22 16 42" src="https://user-images.githubusercontent.com/1231232/52374342-52251d80-2a5d-11e9-91cf-8f8026ad92ff.png">

Exemple avec un code département :

<img width="757" alt="capture d ecran 2019-02-06 a 22 16 50" src="https://user-images.githubusercontent.com/1231232/52374364-5f420c80-2a5d-11e9-890f-13f47fd009fd.png">
