### PR TITLE
Corrige les problèmes de modèle Adresse

### DIFF
--- a/lib/bal/item.js
+++ b/lib/bal/item.js
@@ -50,8 +50,13 @@ export function getCode(item) {
 }
 
 export function getNumeroPos(numero) {
+  if (numero.position) {
+    return numero.position // For /explore model
+  }
+
   const positions = numero.edited ? numero.modified.positions : numero.positions
-  return positions[0]
+
+  return positions ? positions[0] : null
 }
 
 export function getPosition(item) {

--- a/lib/geojson.js
+++ b/lib/geojson.js
@@ -5,6 +5,11 @@ import {randomColor} from 'randomcolor'
 
 import {getStatus, getName, hasPosition, getNumeroPos, getPosition} from './bal/item'
 
+function getCoordinates(position) { // Converge /explore and BAL models
+  const {coords, coordinates} = position
+  return coords || coordinates
+}
+
 function communeContour(commune) {
   const {contour, code, nom} = commune
   return {
@@ -33,17 +38,19 @@ function voieToFeature(voie) {
 
 function toponymeToFeature(toponyme) {
   const position = getPosition(toponyme)
+  const coords = getCoordinates(position)
   const properties = {
     ...toponyme,
     color: randomColor({luminosity: 'dark', seed: toponyme.codeVoie})
   }
 
-  return point(position.coords, properties)
+  return point(coords, properties)
 }
 
 function numeroToFeature(numero) {
   const position = getNumeroPos(numero)
-  const {coords, type} = position
+  const {type} = position
+  const coords = getCoordinates(position)
   const properties = {
     ...numero,
     type
@@ -53,7 +60,8 @@ function numeroToFeature(numero) {
 }
 
 function numeroPositionFeature(position) {
-  const {coords, type} = position
+  const {type} = position
+  const coords = getCoordinates(position)
 
   return point(coords, {type})
 }


### PR DESCRIPTION
La réutilisation des fonctions de conversion en geojson n'était pas compatible entre les deux modèles utilisés pour `/explore` et `/bases-locales`.

Cette PR propose une correction en attendant la convergence des modèles. 