### PR TITLE
Correction mineur d'affichage

### DIFF
--- a/components/faq/index.js
+++ b/components/faq/index.js
@@ -7,7 +7,7 @@ import Question from './question'
 const About = () => (
   <Section>
     <div className='faq-row'>
-      <Section>
+      <div className='theme'>
         <h3>Base Adresse Nationale</h3>
 
         <Question question='Qu’est-ce que la Base Adresse Nationale ?'>
@@ -46,9 +46,9 @@ const About = () => (
         >
           <p>Non, cette base ne fait que référencer l’existence et la localisation géographique d’une adresse. Aucune information personnelle ne figure dans cette base de données.</p>
         </Question>
-      </Section>
+      </div>
 
-      <Section>
+      <div className='theme'>
         <h3>Bases Adresse Locales</h3>
 
         <Question question='Qu’est-ce qu’une Base Adresse Locale ?'>
@@ -79,9 +79,9 @@ const About = () => (
           <p>Par ailleurs seule la Licence Ouverte permet d’alimenter la Base Adresse Nationale, le cadastre, l’INSEE et les principales solutions cartographiques et GPS du marché.</p>
           <p>Si une forme de protectionnisme peut être pertinente sur certaines données publiques, elle est exclus sur les adresses qui sont une donnée fondamentale.</p>
         </Question>
-      </Section>
+      </div>
 
-      <Section>
+      <div className='theme'>
         <h3>API de géocodage</h3>
 
         <Question
@@ -110,14 +110,17 @@ const About = () => (
             <p>Dans le cas contraire, vous pouvez aussi héberger notre API de géocodage chez vous, en suivant <a href='https://github.com/etalab/addok-docker'>ces instructions</a>.</p>
           </>
         </Question>
-      </Section>
+      </div>
 
       <style jsx>{`
-      .faq-row {
-        <section>
-        display: flex;
-        flex-direction: column;
-      }
+        .theme {
+          margin: 1em 0;
+        }
+
+        .faq-row {
+          display: flex;
+          flex-direction: column;
+        }
       `}</style>
     </div>
   </Section>

--- a/components/tools.js
+++ b/components/tools.js
@@ -48,17 +48,21 @@ const Tool = ({title, icon, description, href}) => {
         <div className='article__author-img'>{icon}</div>
         <p className='article__author-description'>{description}</p>
         <style jsx>{`
-        .article__author:hover {
-          cursor: pointer;
-          border-color: ${theme.primary};
-        }
+          .article__author {
+            min-width: 270px;
+          }
 
-        .article__author-img {
-          display: inline-block;
-          float: right;
-          font-size: x-large;
-        }
-      `}</style>
+          .article__author:hover {
+            cursor: pointer;
+            border-color: ${theme.primary};
+          }
+
+          .article__author-img {
+            display: inline-block;
+            float: right;
+            font-size: x-large;
+          }
+        `}</style>
       </div>
     </Link>
   )

--- a/pages/api.js
+++ b/pages/api.js
@@ -184,6 +184,7 @@ export default () => (
 
         .details code {
           color: ${theme.darkText};
+          width: 100%;
         }
 
         @media (min-width: 900px) {

--- a/pages/api.js
+++ b/pages/api.js
@@ -182,6 +182,10 @@ export default () => (
           width: 100%;
         }
 
+        a {
+          color: ${theme.colors.lightBlue};
+        }
+
         .details code {
           color: ${theme.darkText};
           width: 100%;

--- a/pages/cgu.js
+++ b/pages/cgu.js
@@ -73,22 +73,12 @@ export default () => (
       </div>
 
       <style jsx>{`
-        .row {
-          display: flex;
-        }
-
         .row > div:nth-child(2) {
-          width: 80%;
           margin-left: 3em;
         }
 
         @media (max-width: 749px) {
-          .row {
-            flex-wrap: wrap;
-          }
-
           .row > div:nth-child(2) {
-            width: 100%;
             margin-left: 0;
           }
         }

--- a/pages/donnees-nationales.js
+++ b/pages/donnees-nationales.js
@@ -63,7 +63,7 @@ export default () => (
         </div>
       </div>
     </Section>
-    <Notification message='NB : Cette licence est homologuée jusqu’au 31 décembre 2019.' type='error' fullWidth />
+    <Notification message='NB : La licence du produit gratuit issu de la BAN est homologuée jusqu’au 31 décembre 2019.' type='error' fullWidth />
 
     <Section background='grey'>
       <div className='donnees-nationales-section'>


### PR DESCRIPTION
- Réduit l'espace entre les sections de la FAQ
- La taille des `Tool` est la même
-  Utilisation de la `class row` de template.data.gouv.fr dans les CGU
- Affiche le nom de la licence dans l'avertissement concernant l'homologation du produit gratuit issu de la BAN
- Les balises `code` s'élargissent au maximum dans la documentation de l'api
- La couleur des liens hypertexte, dans la documentation de l'api, ont été changés pour être plus lisible