### PR TITLE
Ajout des contrôles de zoom sur les cartes 

### DIFF
--- a/components/map/index.js
+++ b/components/map/index.js
@@ -118,7 +118,7 @@ const Map = ({defaultCenter, defaultZoom}) => {
   }, [zoom, center, getNearestAddress])
 
   return (
-    <div>
+    <div className='interactive-map'>
       <div className='input'>
         <SearchInput
           value={input}
@@ -153,43 +153,41 @@ const Map = ({defaultCenter, defaultZoom}) => {
       </div>
 
       <style jsx>{`
+        .interactive-map {
+          position: relative;
+        }
+
         .input {
-          z-index: 10;
+          z-index: 999;
           width: 40%;
           min-width: 260px;
           position: absolute;
-          top: 90px;
+          top: 16px;
           left: 50%;
           transform: translate(-50%);
         }
 
         .map-container {
           width: 100%;
+          position: relative;
           height: calc(100vh - 73px);
-        }
-
-        @media (max-width: 380px) {
-          .map-container {
-            height: calc(100vh - 63px);
-          }
         }
 
         @media (max-width: 700px) {
           .input {
-            position: absolute;
             min-width: 100%;
-            top: 73px;
+            top: 0;
             left: 0;
             transform: none;
           }
-        }
 
-        @media (max-width: 380px) {
-          .input {
-            top: 63px;
+          .map-container {
+            width: 100%;
+            position: relative;
+            height: calc(100vh - 134px);
+            top: 56px;
           }
         }
-
       `}</style>
     </div >
   )

--- a/components/mapbox/map.js
+++ b/components/mapbox/map.js
@@ -36,7 +36,7 @@ const STYLES = {
   }
 }
 
-const Map = ({switchStyle, bbox, defaultStyle, defaultCenter, defaultZoom, interactive, loading, error, children}) => {
+const Map = ({switchStyle, bbox, defaultStyle, defaultCenter, defaultZoom, interactive, control, loading, error, children}) => {
   const [map, setMap] = useState(null)
   const [mapContainer, setMapContainer] = useState(null)
   const [isFirstLoad, setIsFirstLoad] = useState(false)
@@ -86,6 +86,10 @@ const Map = ({switchStyle, bbox, defaultStyle, defaultCenter, defaultZoom, inter
         zoom: defaultZoom || DEFAULT_ZOOM,
         interactive
       })
+
+      if (control) {
+        map.addControl(new mapboxgl.NavigationControl({showCompass: false}))
+      }
 
       map.once('load', () => {
         setIsFirstLoad(true)
@@ -239,6 +243,7 @@ Map.propTypes = {
     'ortho'
   ]),
   interactive: PropTypes.bool,
+  control: PropTypes.bool,
   defaultCenter: PropTypes.array,
   defaultZoom: PropTypes.number,
   loading: PropTypes.bool,
@@ -250,6 +255,7 @@ Map.defaultProps = {
   bbox: null,
   defaultStyle: 'vector',
   interactive: true,
+  control: true,
   defaultCenter: DEFAULT_CENTER,
   defaultZoom: DEFAULT_ZOOM,
   loading: false,

--- a/components/mapbox/map.js
+++ b/components/mapbox/map.js
@@ -209,7 +209,7 @@ const Map = ({switchStyle, bbox, defaultStyle, defaultCenter, defaultZoom, inter
 
           .tools {
             position: absolute;
-            z-index: 999;
+            z-index: 900;
             padding: 0.5em;
             margin: 1em;
             border-radius: 4px;


### PR DESCRIPTION
Le composant `Map` ajoute par défaut les contrôles de zoom sur les cartes.

Cette PR apporte également des corrections à l'affichage de la carte interactive. En effet, sur mobile la barre de recherche pouvez être cachée par l'adresse et le contrôleur de la carte caché par la barre de recherche.