### PR TITLE
Corrige l'affichage des informations de la carte

### DIFF
--- a/components/mapbox/map.js
+++ b/components/mapbox/map.js
@@ -209,6 +209,8 @@ const Map = ({switchStyle, bbox, defaultStyle, defaultCenter, defaultZoom, inter
 
           .tools {
             position: absolute;
+            max-height: ${switchStyle ? 'calc(100% - 116px)' : '100%'};
+            overflow: ${switchStyle ? 'scroll' : 'initial'};
             z-index: 900;
             padding: 0.5em;
             margin: 1em;


### PR DESCRIPTION
Lorsque les informations à afficher sont trop grande pour la carte, celle-ci entrées en collision avec le changement de style de la carte.

### Avant
![Capture d’écran 2019-08-28 à 14 59 02](https://user-images.githubusercontent.com/7040549/63858358-9f3ef180-c9a5-11e9-99db-1d696989d092.png)

### Après
![map tools scroll](https://user-images.githubusercontent.com/7040549/63858313-90583f00-c9a5-11e9-85d3-2c5772d1729b.gif)
