### PR TITLE
Suppression de composant <Container> de next

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import App, {Container} from 'next/app'
+import App from 'next/app'
 import getConfig from 'next/config'
 
 const {publicRuntimeConfig: {
@@ -41,11 +41,7 @@ class MyApp extends App {
   render() {
     const {Component, pageProps} = this.props
 
-    return (
-      <Container>
-        <Component {...pageProps} />
-      </Container>
-    )
+    return <Component {...pageProps} />
   }
 }
 


### PR DESCRIPTION
L'utilisation du composant <Container> dans `./pages/_app.js` est désormais déprécié.
Cf https://github.com/zeit/next.js/blob/master/errors/app-container-deprecated.md