### PR TITLE
Correction de la superposition des labels

### DIFF
--- a/components/mapbox/layers/positions.js
+++ b/components/mapbox/layers/positions.js
@@ -75,10 +75,8 @@ export function getPositionsLabelLayer(style) {
     layout: {
       'text-font': ['Noto Sans Regular'],
       'text-field': '{source}',
-      'text-anchor': 'left',
-      'text-justify': 'center',
-      'text-radial-offset': 1,
-      'text-ignore-placement': true
+      'text-variable-anchor': ['bottom', 'top', 'right', 'left'],
+      'text-radial-offset': 1
     }
   }
 


### PR DESCRIPTION
Ajout de d'encrage variable pour les labels permettant ainsi à Mapbox d'éviter les collisions quand c'est possible.

## Avant
<img width="350" alt="Capture d’écran 2019-10-09 à 12 25 16" src="https://user-images.githubusercontent.com/7040549/66473979-aa02a100-ea90-11e9-9e1e-1b0d66b2f66d.png">

## Après
<img width="350" alt="Capture d’écran 2019-10-09 à 12 25 21" src="https://user-images.githubusercontent.com/7040549/66473975-a96a0a80-ea90-11e9-979b-b6beecb0c24c.png">

Fix #454 