### PR TITLE
replace radio-input by checkbox-input

### DIFF
--- a/components/explorer/commune/codes.js
+++ b/components/explorer/commune/codes.js
@@ -39,6 +39,7 @@ const Codes = ({code, codesPostaux, departement, region, population}) => (
 
 Codes.propTypes = {
   codesPostaux: PropTypes.array.isRequired,
+  population: PropTypes.number.isRequired,
   code: PropTypes.string.isRequired,
   departement: PropTypes.shape({
     nom: PropTypes.string.isRequired,

--- a/components/explorer/commune/codes.js
+++ b/components/explorer/commune/codes.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 
 import theme from '../../../styles/theme'
 
-const Codes = ({code, codesPostaux, departement, region}) => (
+const Codes = ({code, codesPostaux, departement, region, population}) => (
   <div className='codes'>
     <div><b>Code commune</b> : {code}</div>
     {codesPostaux.length > 1 ?
@@ -16,11 +16,12 @@ const Codes = ({code, codesPostaux, departement, region}) => (
       <div><b>Code postal</b> : {codesPostaux[0]}</div>}
     <div><b>Département</b> : {departement.nom} ({departement.code})</div>
     <div><b>Région</b> : {region.nom} ({region.code})</div>
+    <div><b>Habitants</b> : {population.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ')}</div>
     <style jsx>{`
       .codes {
         display: grid;
         text-align: center;
-        grid-template-columns: repeat(4, 1fr);
+        grid-template-columns: repeat(5, 1fr);
         background-color: ${theme.primary};
         color: ${theme.colors.white};
         margin-top: -1em;

--- a/components/explorer/commune/head.js
+++ b/components/explorer/commune/head.js
@@ -14,7 +14,7 @@ const Head = ({nom, code, departement}) => (
         flex-flow: wrap;
         align-items: center;
         border-bottom: 2px solid ${theme.colors.black};
-        margin: 2em 0;
+        margin: -3em 0 2em 0;
       }
       `}</style>
   </div>

--- a/components/explorer/commune/index.js
+++ b/components/explorer/commune/index.js
@@ -18,18 +18,18 @@ const Commune = props => (
 
     <div className='head'>
       <Codes {...props} />
+      <Metrics {...props} />
     </div>
 
     <div className='preview'>
-      <Metrics {...props} />
       <div className='explore-commune-map'>
         <Mapbox bbox={computeBbox(props.contour)} switchStyle>
           {({...mapboxProps}) => (
             <AddressesMap
-              {...mapboxProps}
-              contour={props.contour}
+            {...mapboxProps}
+            contour={props.contour}
             />
-          )}
+            )}
         </Mapbox>
       </div>
     </div>

--- a/components/explorer/commune/index.js
+++ b/components/explorer/commune/index.js
@@ -29,7 +29,7 @@ const Commune = props => (
               {...mapboxProps}
               contour={props.contour}
             />
-            )}
+          )}
         </Mapbox>
       </div>
     </div>

--- a/components/explorer/commune/index.js
+++ b/components/explorer/commune/index.js
@@ -26,8 +26,8 @@ const Commune = props => (
         <Mapbox bbox={computeBbox(props.contour)} switchStyle>
           {({...mapboxProps}) => (
             <AddressesMap
-            {...mapboxProps}
-            contour={props.contour}
+              {...mapboxProps}
+              contour={props.contour}
             />
             )}
         </Mapbox>

--- a/components/explorer/commune/metrics.js
+++ b/components/explorer/commune/metrics.js
@@ -12,7 +12,7 @@ const Metrics = ({population, surface}) => (
     </div>
     <div className='metric'>
       <FaArrowsAlt size={40} />
-      <div>{surface / 100} km²</div>
+      <div>{(surface / 100).toFixed(5)} km²</div>
     </div>
     <style jsx>{`
       .metrics {

--- a/components/explorer/commune/metrics.js
+++ b/components/explorer/commune/metrics.js
@@ -7,17 +7,17 @@ import FaArrowsAlt from 'react-icons/lib/fa/arrows-alt'
 const Metrics = ({population, surface}) => (
   <div className='metrics'>
     <div className='metric'>
-      <FaGroup size={40} />
+      <FaGroup size={30} />
       <div>{population.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ')} habitants</div>
     </div>
     <div className='metric'>
-      <FaArrowsAlt size={40} />
+      <FaArrowsAlt size={30} />
       <div>{(surface / 100).toFixed(5)} km²</div>
     </div>
     <style jsx>{`
       .metrics {
         display: flex;
-        flex-direction: column;
+        flex-direction: row;
         justify-content: space-around;
       }
 

--- a/components/explorer/commune/metrics.js
+++ b/components/explorer/commune/metrics.js
@@ -6,14 +6,14 @@ import FaArrowsAlt from 'react-icons/lib/fa/arrows-alt'
 
 const Metrics = ({population, surface}) => (
   <div className='metrics'>
-    <div className='metric'>
+    {/* <div className='metric'>
       <FaGroup size={30} />
       <div>{population.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ')} habitants</div>
-    </div>
-    <div className='metric'>
+    </div> */}
+    {/* <div className='metric'>
       <FaArrowsAlt size={30} />
       <div>{(surface / 100).toFixed(5)} km²</div>
-    </div>
+    </div> */}
     <style jsx>{`
       .metrics {
         display: flex;

--- a/components/explorer/commune/metrics.js
+++ b/components/explorer/commune/metrics.js
@@ -26,11 +26,6 @@ const Metrics = ({population, surface}) => (
         padding: 1em;
       }
 
-      @media (max-width: 749px) {
-        .metrics {
-          flex-direction: row;
-        }
-      }
         `}</style>
   </div>
 )

--- a/components/explorer/commune/metrics.js
+++ b/components/explorer/commune/metrics.js
@@ -1,19 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import FaGroup from 'react-icons/lib/fa/group'
-import FaArrowsAlt from 'react-icons/lib/fa/arrows-alt'
-
-const Metrics = ({population, surface}) => (
+const Metrics = ({population}) => (
   <div className='metrics'>
-    {/* <div className='metric'>
-      <FaGroup size={30} />
+    <div className='metric'>
       <div>{population.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ')} habitants</div>
-    </div> */}
-    {/* <div className='metric'>
-      <FaArrowsAlt size={30} />
-      <div>{(surface / 100).toFixed(5)} km²</div>
-    </div> */}
+    </div>
     <style jsx>{`
       .metrics {
         display: flex;
@@ -31,8 +23,7 @@ const Metrics = ({population, surface}) => (
 )
 
 Metrics.propTypes = {
-  population: PropTypes.number.isRequired,
-  surface: PropTypes.number.isRequired
+  population: PropTypes.number.isRequired
 }
 
 export default Metrics

--- a/components/explorer/table-list/filters/checkbox-input.js
+++ b/components/explorer/table-list/filters/checkbox-input.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-class RadioInput extends React.Component {
+class CheckboxInput extends React.Component {
   static propTypes = {
     value: PropTypes.string.isRequired,
     toggleInput: PropTypes.func.isRequired,
@@ -25,11 +25,11 @@ class RadioInput extends React.Component {
 
     return (
       <div style={style} className='input'>
-        <input type='radio' id={`radio-${value}`} value={value} checked={isChecked} onClick={this.handleChange} />
+        <input type='checkbox' id={`checkbox-${value}`} value={value} checked={isChecked} onClick={this.handleChange} />
         <label className='label-inline'>{value}</label>
       </div>
     )
   }
 }
 
-export default RadioInput
+export default CheckboxInput

--- a/components/explorer/table-list/filters/tags-input.js
+++ b/components/explorer/table-list/filters/tags-input.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import RadioInput from './radio-input'
+import CheckboxInput from './checkbox-input'
 
 class TagsInput extends React.Component {
   static propTypes = {
@@ -18,7 +18,7 @@ class TagsInput extends React.Component {
         <div className='title'>{title}</div>
         <div className='tags'>
           {tags.map(tag => (
-            <RadioInput
+            <CheckboxInput
               key={tag}
               style={{display: 'flex', alignItems: 'flex-start', margin: '5px 10px 0'}}
               value={tag}

--- a/components/explorer/voie/head.js
+++ b/components/explorer/voie/head.js
@@ -20,7 +20,7 @@ const Head = ({commune, nomVoie}) => {
           flex-flow: wrap;
           align-items: center;
           border-bottom: 2px solid ${theme.colors.black};
-          margin: 2em 0;
+          margin: -3em 0 2em 0;
         }
 
         h4 {


### PR DESCRIPTION
La classe **RadioInput** devient **CheckboxInput**.
Les inputs "_radio_" sont remplacés par des "_checkbox_".
Le fichier `components/explorer/tablea-list/filters/radio-input.js` devient `components/explorer/tablea-list/filters/checkbox-input.js`.