### PR TITLE
Modification du visuel de Numéro & Ajout du switch-map

### DIFF
--- a/components/mapbox/layers/numeros.js
+++ b/components/mapbox/layers/numeros.js
@@ -51,26 +51,16 @@ export function getNumerosLabelLayer() {
     interactive: true,
     minzoom: NUMEROS_MIN,
     paint: {
-      'text-color': '#ffffff',
-      'text-halo-color': {
+      'text-color': {
         type: 'identity',
         property: 'color'
       },
-      'text-halo-width': {
-        stops: [
-          [12, 1.5],
-          [18, 2]
-        ]
-      },
-      'text-opacity': [
-        'case',
-        ['boolean', ['feature-state', 'hover'], false],
-        1,
-        0.6
-      ]
+      'text-halo-color': 'rgb(250, 250, 250)',
+      'text-halo-width': 1
     },
     layout: {
-      'text-font': ['Noto Sans Regular'],
+      'text-font': ['Noto Sans Bold'],
+      'text-size': 18,
       'text-field': [
         'case',
         ['has', 'suffixe'],

--- a/components/mapbox/layers/numeros.js
+++ b/components/mapbox/layers/numeros.js
@@ -75,7 +75,9 @@ export function getNumerosLabelLayer() {
         ],
         ['get', 'numero']
       ],
-      'text-ignore-placement': true
+      'text-ignore-placement': false,
+      'text-variable-anchor': ['bottom', 'top', 'right', 'left'],
+      'text-radial-offset': 0.4
     }
   }
 

--- a/components/mapbox/layers/numeros.js
+++ b/components/mapbox/layers/numeros.js
@@ -55,7 +55,7 @@ export function getNumerosLabelLayer() {
         type: 'identity',
         property: 'color'
       },
-      'text-halo-color': 'rgb(250, 250, 250)',
+      'text-halo-color': '#ffffff',
       'text-halo-width': 1
     },
     layout: {

--- a/components/mapbox/map.js
+++ b/components/mapbox/map.js
@@ -263,7 +263,7 @@ Map.defaultProps = {
   defaultZoom: DEFAULT_ZOOM,
   isLoading: false,
   error: null,
-  hasSwitchStyle: false
+  hasSwitchStyle: true
 }
 
 export default Map


### PR DESCRIPTION
- Correction de l'affichage de numéros partageant la même position
- Changement du visuel des Numéros
- Ajout du switch pour changer le style de la carte (Vectoriel / Satellite) 

Avant :
![Capture d’écran 2019-12-20 à 15 44 10](https://user-images.githubusercontent.com/56537238/71262448-065f2800-2340-11ea-917c-35d02eecdc4b.png)

Après : 
![Capture d’écran 2019-12-20 à 15 45 11](https://user-images.githubusercontent.com/56537238/71262470-15de7100-2340-11ea-8b19-71f7717c65f1.png)
