### PR TITLE
Ajout de padding et media-query sur le bandeau Licence Libre

### DIFF
--- a/components/open-licence-ribbon.js
+++ b/components/open-licence-ribbon.js
@@ -15,7 +15,7 @@ const OpenLicenceRibbon = () => (
         margin-left: 0.5em;
         align-content: center;
       }
-      
+
       .ribbon{
         display: flex;
         align-items: center;
@@ -24,10 +24,17 @@ const OpenLicenceRibbon = () => (
         min-height: 80px;
         color: ${theme.colors.almostBlack};
         font-size: 19px;
+        padding: 1em;
       }
-      
+
       .ribbon-content{
         text-align: center;
+      }
+
+      @media (max-width: 700px) {
+        img {
+          display: none;
+        }
       }
     `}</style>
   </div>


### PR DESCRIPTION
<img width="341" alt="Capture d’écran 2019-12-27 à 16 15 54" src="https://user-images.githubusercontent.com/56537238/71522257-2fddfd80-28c4-11ea-9d56-adb26c5e22d6.png">
