### PR TITLE
Retrait de la colorisation différenciée des BAL selon la licence

### DIFF
--- a/components/bases-locales/bal-cover-map.js
+++ b/components/bases-locales/bal-cover-map.js
@@ -138,14 +138,14 @@ class BalCoverMap extends React.Component {
   render() {
     return (
       <div className='legend'>
-        <div>
-          <i className='bal' /> Communes couvertes par une Base Adresse Locale
-        </div>
+        <i className='bal' /> Communes couvertes par une Base Adresse Locale
 
         <style jsx>{`
           .legend {
             z-index: 1;
             position: absolute;
+            display: flex;
+            align-items: center;
             padding: 1em;
             margin: 1em;
             background: #ffffffc4;

--- a/components/bases-locales/bal-cover-map.js
+++ b/components/bases-locales/bal-cover-map.js
@@ -52,7 +52,7 @@ class BalCoverMap extends React.Component {
             'case',
             ['boolean', ['feature-state', 'hover'], false],
             0.5,
-            0.1
+            0.2
           ]
         },
         filter: ['==', '$type', 'Polygon']
@@ -63,7 +63,7 @@ class BalCoverMap extends React.Component {
         source: 'data',
         paint: {
           'line-color': theme.colors.green,
-          'line-width': 2
+          'line-width': 1
         },
         filter: ['==', '$type', 'Polygon']
       }

--- a/components/bases-locales/bal-cover-map.js
+++ b/components/bases-locales/bal-cover-map.js
@@ -47,14 +47,7 @@ class BalCoverMap extends React.Component {
         type: 'fill',
         source: 'data',
         paint: {
-          'fill-color': [
-            'case',
-            ['==', ['get', 'license'], 'odc-odbl'],
-            theme.colors.orange,
-            ['==', ['get', 'license'], 'lov2'],
-            theme.colors.green,
-            theme.colors.red
-          ],
+          'fill-color': theme.colors.green,
           'fill-opacity': [
             'case',
             ['boolean', ['feature-state', 'hover'], false],
@@ -69,14 +62,7 @@ class BalCoverMap extends React.Component {
         type: 'line',
         source: 'data',
         paint: {
-          'line-color': [
-            'case',
-            ['==', ['get', 'license'], 'odc-odbl'],
-            theme.colors.orange,
-            ['==', ['get', 'license'], 'lov2'],
-            theme.colors.green,
-            theme.colors.red
-          ],
+          'line-color': theme.colors.green,
           'line-width': 2
         },
         filter: ['==', '$type', 'Polygon']
@@ -153,10 +139,7 @@ class BalCoverMap extends React.Component {
     return (
       <div className='legend'>
         <div>
-          <i className='lov2' /> BAL disponible sous Licence Ouverte
-        </div>
-        <div>
-          <i className='odbl' /> BAL disponible sous licence ODbL
+          <i className='bal' /> Communes couvertes par une Base Adresse Locale
         </div>
 
         <style jsx>{`
@@ -177,12 +160,8 @@ class BalCoverMap extends React.Component {
             opacity: .7;
           }
 
-          .legend .lov2 {
+          .legend .bal {
             background: ${theme.colors.green};
-          }
-
-          .legend .odbl {
-            background: ${theme.colors.orange};
           }
         `}</style>
       </div>


### PR DESCRIPTION
La Base Adresse Nationale étant passée sous Licence Ouverte, l'incorporation des BAL dans celle-ci, quelles que soient leurs licences sources est facilitée.

Il n'est plus nécessaire de conduire la politique de convergence à ce stade.

Avant

<img width="1016" alt="Capture d’écran 2020-01-13 à 14 03 46" src="https://user-images.githubusercontent.com/1231232/72258228-d7219b00-360d-11ea-8f53-1bcc11b001a0.png">

Après

<img width="1014" alt="Capture d’écran 2020-01-13 à 14 03 28" src="https://user-images.githubusercontent.com/1231232/72258231-d983f500-360d-11ea-961b-f7a0573cd0a3.png">
