### PR TITLE
Ajout de isExternal pour les liens externes

### DIFF
--- a/components/bases-locales/bases-adresse-locales/summary.js
+++ b/components/bases-locales/bases-adresse-locales/summary.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import Link from 'next/link'
 import {Download} from 'react-feather'
 
 import ButtonLink from '../../button-link'
@@ -55,9 +54,7 @@ class Summary extends React.Component {
               Consulter
             </ButtonLink>
             {url &&
-              <Link href={url}>
-                <a>Télécharger <Download size={18} style={{verticalAlign: 'middle', marginLeft: '3px'}} /></a>
-              </Link>}
+              <a href={url}>Télécharger <Download size={18} style={{verticalAlign: 'middle', marginLeft: '3px'}} /></a>}
           </div>
         </div>
 

--- a/components/bases-locales/index.js
+++ b/components/bases-locales/index.js
@@ -69,6 +69,7 @@ const BasesLocales = React.memo(({datasets, stats}) => {
 
           <div className='button-link'>
             <ButtonLink
+              isExternal
               size='large'
               href='https://editeur.adresse.data.gouv.fr/new'
             >
@@ -78,6 +79,7 @@ const BasesLocales = React.memo(({datasets, stats}) => {
 
           <div className='button-link'>
             <ButtonLink
+              isExternal
               size='large'
               href='https://editeur.adresse.data.gouv.fr/new/upload'
             >

--- a/components/button-link.js
+++ b/components/button-link.js
@@ -2,13 +2,23 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import Link from 'next/link'
 
+const regex = /^http?/
+
 const ButtonLink = ({size, color, href, isOutlined, children, ...props}) => {
   return (
-    <Link href={href}>
-      <a className={`button${isOutlined ? '-outline' : ''} ${size} ${color}`} {...props}>
-        {children}
-      </a>
-    </Link>
+    <>
+      {regex.test(href) ? (
+        <a href={href} className={`button${isOutlined ? '-outline' : ''} ${size} ${color}`} {...props}>
+          {children}
+        </a>
+      ) : (
+        <Link href={href}>
+          <a className={`button${isOutlined ? '-outline' : ''} ${size} ${color}`} {...props}>
+            {children}
+          </a>
+        </Link>
+      )}
+    </>
   )
 }
 

--- a/components/button-link.js
+++ b/components/button-link.js
@@ -2,12 +2,10 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import Link from 'next/link'
 
-const regex = /^http?/
-
-const ButtonLink = ({size, color, href, isOutlined, children, ...props}) => {
+const ButtonLink = ({size, color, href, isOutlined, isExternal, children, ...props}) => {
   return (
     <>
-      {regex.test(href) ? (
+      {isExternal ? (
         <a href={href} className={`button${isOutlined ? '-outline' : ''} ${size} ${color}`} {...props}>
           {children}
         </a>
@@ -35,6 +33,7 @@ ButtonLink.propTypes = {
   ]),
   href: PropTypes.string.isRequired,
   isOutlined: PropTypes.bool,
+  isExternal: PropTypes.bool,
   children: PropTypes.node
 }
 
@@ -42,6 +41,7 @@ ButtonLink.defaultProps = {
   size: null,
   color: 'primary',
   isOutlined: false,
+  isExternal: false,
   children: null
 }
 

--- a/pages/contribuer.js
+++ b/pages/contribuer.js
@@ -26,7 +26,7 @@ export default () => (
         <section>
           <h3>Utiliser le Guichet Adresse de l’IGN et de La Poste</h3>
           <p>Cet outil est destiné plus particulièrement aux mairies qui souhaitent avoir une assistance renforcée. Le processus est plus guidé, et vous n’avez aucun fichier à gérer.</p>
-          <ButtonLink href='https://guichet-adresse.ign.fr'><ExternalLink style={{verticalAlign: 'bottom', marginRight: '5px'}} /> Accéder au Guichet Adresse</ButtonLink>
+          <ButtonLink isExternal href='https://guichet-adresse.ign.fr'><ExternalLink style={{verticalAlign: 'bottom', marginRight: '5px'}} /> Accéder au Guichet Adresse</ButtonLink>
         </section>
       </div>
     </Section>


### PR DESCRIPTION
- Fix issue #572 
  - ajout d'un boolean `isExternal` dans le composant `<ButtonLink>` pour les liens externes
  - ajout de la props `isExternal` dans les liens externes des fichiers :
    - `components/bases-locales/index.js`
    - `/components/bases-locales/bases-adresses-locales/dataset/index.js`
    - `pages/contribuer.js`