### PR TITLE
Correction d'affichage des résultats de recherche dans /explore

### DIFF
--- a/components/search-input/index.js
+++ b/components/search-input/index.js
@@ -104,7 +104,7 @@ class SearchInput extends React.Component {
           .menu {
             position: absolute;
             box-shadow: 0 1px 4px ${theme.boxShadow};
-            z-index: 1;
+            z-index: 5;
             width: 100%;
             background-color: ${theme.colors.white};
             border: 1px solid ${theme.border};


### PR DESCRIPTION
Fix #579 

- Augmentation du `z-index` dans le composant `<SearchInput />`

Les résultats sont maintenant affichés au dessus du contrôle de zoom de la carte.