### PR TITLE
Ajout de la source des libellés de voie dans /explore 

### DIFF
--- a/components/explorer/voie/index.js
+++ b/components/explorer/voie/index.js
@@ -9,6 +9,7 @@ import Tag from '../../tag'
 
 import Head from './head'
 import MapContainer from './map-container'
+import SourcesVoie from './sources-voie'
 
 const Voie = ({commune, voie, numero}) => {
   const handleSelect = ({numero, suffixe}) => {
@@ -54,6 +55,7 @@ const Voie = ({commune, voie, numero}) => {
         addresses={voie.numeros}
         numero={numero}
         onSelect={(numero, suffixe) => handleSelect({numero, suffixe})} />
+      <SourcesVoie voie={voie} />
       <TableList
         title='Adresses de la voie'
         subtitle={voie.numerosCount === 1 ? `${voie.numerosCount} adresse répertoriée` : `${voie.numerosCount} adresses répertoriées`}

--- a/components/explorer/voie/sources-voie.js
+++ b/components/explorer/voie/sources-voie.js
@@ -1,0 +1,75 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import {Check} from 'react-feather'
+
+import Tag from '../../tag'
+
+const SourcesVoie = ({voie}) => {
+  const sourceNom = voie.sourceNomVoie
+  return (
+    <div>
+      <h3>Origine du nom de la voie</h3>
+      <div className='resume centered'><i>Le tableau suivant liste tous les libellés rencontrés dans les différentes sources ayant permis de produire le fichier Adresses, ainsi que le nombre d’occurences. Le libellé retenu par l’algorithme est indiqué en vert.</i></div>
+      <tbody className='table-container'>
+        <tr>
+          <th />
+          <th>Libellé</th>
+          <th>Source</th>
+          <th>Nombre d’occurences</th>
+        </tr>
+        {voie.nomsVoie.map(nom => {
+          return (
+            <tr key={nom.index} className='sources' style={sourceNom === nom.source ? {backgroundColor: '#d6f5d6'} : null} >
+              <td className='centered'>
+                {sourceNom === nom.source && (
+                  <Check style={{verticalAlign: 'middle', margin: 'auto'}} />
+                )}
+              </td>
+              <td>{nom.nomVoie}</td>
+              <td><Tag key={nom.source} type={nom.source} style={{display: 'inline-flex'}} /></td>
+              <td>{nom.count}</td>
+            </tr>
+          )
+        })}
+      </tbody>
+      <style jsx>{`
+        h3 {
+          margin-top: 1em;
+          margin-bottom: 0;
+        }
+
+        th {
+          background-color: #0053b3;
+          color: #ffffff;
+        }
+
+        td, th {
+          padding: .5em;
+          border: .5px solid lightgrey;
+        }
+
+        .table-container {
+          width: 100%;
+          display: inline-table;
+          margin-bottom: 1.5em;
+          border: .5px solid lightgrey;
+        }
+
+        .resume {
+          padding: 1em;
+        }
+
+        .centered {
+          text-align: center;
+        }
+
+        `}</style>
+    </div>
+  )
+}
+
+SourcesVoie.propTypes = {
+  voie: PropTypes.object.isRequired
+}
+
+export default SourcesVoie

--- a/components/explorer/voie/sources-voie.js
+++ b/components/explorer/voie/sources-voie.js
@@ -6,6 +6,7 @@ import Tag from '../../tag'
 
 const SourcesVoie = ({voie}) => {
   const {sourceNomVoie} = voie
+
   return (
     <div>
       <h3>Origine du nom de la voie</h3>
@@ -73,8 +74,10 @@ const SourcesVoie = ({voie}) => {
 }
 
 SourcesVoie.propTypes = {
-  voie: PropTypes.object.isRequired,
-  sourceNomVoie: PropTypes.object.isRequired
+  voie: PropTypes.shape({
+    sourceNomVoie: PropTypes.string.isRequired,
+    nomsVoie: PropTypes.array.isRequired
+  }).isRequired
 }
 
 export default SourcesVoie

--- a/components/explorer/voie/sources-voie.js
+++ b/components/explorer/voie/sources-voie.js
@@ -5,7 +5,7 @@ import {Check} from 'react-feather'
 import Tag from '../../tag'
 
 const SourcesVoie = ({voie}) => {
-  const sourceNom = voie.sourceNomVoie
+  const {sourceNomVoie} = voie
   return (
     <div>
       <h3>Origine du nom de la voie</h3>
@@ -19,9 +19,9 @@ const SourcesVoie = ({voie}) => {
         </tr>
         {voie.nomsVoie.map(nom => {
           return (
-            <tr key={nom.index} className='sources' style={sourceNom === nom.source ? {backgroundColor: '#d6f5d6'} : null} >
+            <tr key={nom.index} className={sourceNomVoie === nom.source ? 'highlighted' : ''} >
               <td className='centered'>
-                {sourceNom === nom.source && (
+                {sourceNomVoie === nom.source && (
                   <Check style={{verticalAlign: 'middle', margin: 'auto'}} />
                 )}
               </td>
@@ -63,13 +63,18 @@ const SourcesVoie = ({voie}) => {
           text-align: center;
         }
 
+        .highlighted {
+          background-color: #d6f5d6;
+        }
+
         `}</style>
     </div>
   )
 }
 
 SourcesVoie.propTypes = {
-  voie: PropTypes.object.isRequired
+  voie: PropTypes.object.isRequired,
+  sourceNomVoie: PropTypes.object.isRequired
 }
 
 export default SourcesVoie


### PR DESCRIPTION
Fix #527 

<img width="875" alt="Capture d’écran 2020-03-04 à 17 06 19" src="https://user-images.githubusercontent.com/56537238/75898574-8b83b480-5e3a-11ea-92c4-c41f788d106e.png">

