### PR TITLE
[Explore/Commune/Voie] 'undefined' dans la barre d'adresse 

### DIFF
--- a/components/explorer/commune/voies-commune.js
+++ b/components/explorer/commune/voies-commune.js
@@ -57,7 +57,9 @@ const VoiesCommune = ({voies, commune}) => {
 
 VoiesCommune.propTypes = {
   voies: PropTypes.array,
-  commune: PropTypes.object
+  commune: PropTypes.shape({
+    code: PropTypes.string.isRequired
+  })
 }
 
 VoiesCommune.defaultProps = {

--- a/components/explorer/commune/voies-commune.js
+++ b/components/explorer/commune/voies-commune.js
@@ -31,7 +31,7 @@ const VoiesCommune = ({voies, commune}) => {
   const handleSelect = ({idVoie}) => {
     Router.push(
       `/commune/voie?idVoie=${idVoie}`,
-      `/explore/commune/${commune.codeCommune}/voie/${idVoie}`
+      `/explore/commune/${commune.code}/voie/${idVoie}`
     )
   }
 

--- a/pages/explore/commune.js
+++ b/pages/explore/commune.js
@@ -32,7 +32,7 @@ const CommunePage = ({commune, voiesInfos}) => {
 
       <Section>
         <Commune commune={commune} voiesInfos={voiesInfos} />
-        <VoiesCommune voies={voies} style={{height: '300px'}} />
+        <VoiesCommune voies={voies} commune={commune} style={{height: '300px'}} />
       </Section>
     </Page>
   )


### PR DESCRIPTION
Sur la page `explore/commune/voie` la barre d'adresse affichait `undefined`
- **Exemple**
https://adresse.data.gouv.fr/explore/commune/undefined/voie/57463_2995

- **Capture d'écran**
![Capture du 2020-03-16 11-15-41](https://user-images.githubusercontent.com/45098730/76746917-90206500-6778-11ea-9445-dceea419bf5b.png)
