### PR TITLE
Utilisation des routes dynamiques pour les pages /explore

### DIFF
--- a/components/explorer/voie/index.js
+++ b/components/explorer/voie/index.js
@@ -13,9 +13,9 @@ import SourcesTable from '../../sources-table'
 
 const Voie = ({commune, voie, numero}) => {
   const handleSelect = ({numero, suffixe}) => {
-    const {codeCommune, idVoie} = Router.query
+    const {codeCommune, additional} = Router.query
 
-    Router.push(`/explore/commune/${codeCommune}/voie/${idVoie}${numero ? `/numero/${numero}${suffixe || ''}` : ''}`)
+    Router.push(`/explore/commune/${codeCommune}/voie/${additional[0]}/numero/${suffixe ? `${numero}${suffixe}` : numero}`)
   }
 
   const checkIsSelected = item => {

--- a/pages/explore/commune/[codeCommune]/index.js
+++ b/pages/explore/commune/[codeCommune]/index.js
@@ -1,15 +1,15 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import {getCommune} from '../../lib/api-geo'
-import {getCommune as getCommuneExplore} from '../../lib/explore/api'
+import {getCommune} from '../../../../lib/api-geo'
+import {getCommune as getCommuneExplore} from '../../../../lib/explore/api'
 
-import Page from '../../layouts/main'
-import Section from '../../components/section'
-import withErrors from '../../components/hoc/with-errors'
+import Page from '../../../../layouts/main'
+import Section from '../../../../components/section'
+import withErrors from '../../../../components/hoc/with-errors'
 
-import Header from '../../components/explorer/header'
-import Commune from '../../components/explorer/commune'
-import VoiesCommune from '../../components/explorer/commune/voies-commune'
+import Header from '../../../../components/explorer/header'
+import Commune from '../../../../components/explorer/commune'
+import VoiesCommune from '../../../../components/explorer/commune/voies-commune'
 
 const contourToFeatureCollection = commune => {
   return {

--- a/pages/explore/commune/[codeCommune]/voie/[...additional].js
+++ b/pages/explore/commune/[codeCommune]/voie/[...additional].js
@@ -1,14 +1,14 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import Page from '../../../layouts/main'
+import Page from '../../../../../layouts/main'
 
-import {getVoie, getNumero} from '../../../lib/explore/api'
+import {getVoie, getNumero} from '../../../../../lib/explore/api'
 
-import withErrors from '../../../components/hoc/with-errors'
+import withErrors from '../../../../../components/hoc/with-errors'
 
-import Header from '../../../components/explorer/header'
-import Voie from '../../../components/explorer/voie'
+import Header from '../../../../../components/explorer/header'
+import Voie from '../../../../../components/explorer/voie'
 
 class VoieError extends Error {
   constructor(message) {
@@ -43,13 +43,18 @@ VoiePage.defaultProps = {
 }
 
 VoiePage.getInitialProps = async ({query}) => {
-  const {idVoie} = query
+  const {additional} = query
+  const [idVoie] = additional
   const promises = [
     getVoie(idVoie)
   ]
 
-  if (query.numero) {
-    promises.push(getNumero(idVoie, query.numero))
+  if (additional.length === 2 || additional.length > 3 || (additional.length > 1 && additional[1] !== 'numero')) {
+    throw new VoieError()
+  }
+
+  if (additional[1] === 'numero' && additional[2]) {
+    promises.push(getNumero(idVoie, additional[2]))
   }
 
   const [voie, numero] = await Promise.all(promises)

--- a/server.js
+++ b/server.js
@@ -18,30 +18,6 @@ app.prepare().then(() => {
     app.render(req, res, '/contact')
   })
 
-  server.get('/explore/commune/:code', (req, res) => {
-    app.render(req, res, '/explore/commune', {
-      ...req.query,
-      codeCommune: req.params.code
-    })
-  })
-
-  server.get('/explore/commune/:codeCommune/voie/:idVoie', (req, res) => {
-    app.render(req, res, '/explore/commune/voie', {
-      ...req.query,
-      codeCommune: req.params.codeCommune,
-      idVoie: req.params.idVoie
-    })
-  })
-
-  server.get('/explore/commune/:codeCommune/voie/:idVoie/numero/:numero', (req, res) => {
-    app.render(req, res, '/explore/commune/voie', {
-      ...req.query,
-      codeCommune: req.params.codeCommune,
-      idVoie: req.params.idVoie,
-      numero: req.params.numero
-    })
-  })
-
   server.get('/bases-locales/validateur', (req, res) => {
     app.render(req, res, '/bases-locales/validator', {
       ...req.query


### PR DESCRIPTION
- Suppression de la gestion des routes  `/explore` par express
- `pages/explore/commune.js` devient -> `pages/explore/commune/[codeCommune]/index.js`
- `pages/explore/commune/voie.js` devient -> `pages/explore/commune/[codeCommune]/voie/[...additional].js`
- Adaptation du composant `Voie`aux nouvelles routes dynamiques : 
  - `components/explorer/voie/index.js`
  - `components/explorer/voie/map-container.js`