### PR TITLE
Correction de l'erreur d'identifiant de "feature" renvoyée par MapBoxGL

### DIFF
--- a/components/mapbox/hooks/sources.js
+++ b/components/mapbox/hooks/sources.js
@@ -28,6 +28,7 @@ function useSources(contour, voies, numeros, numero) {
         numeros.features
 
       sources.push({
+        generateId: true,
         name: 'numeros',
         type: 'geojson',
         data: {type: 'FeatureCollection', features}

--- a/components/mapbox/hooks/sources.js
+++ b/components/mapbox/hooks/sources.js
@@ -37,6 +37,7 @@ function useSources(contour, voies, numeros, numero) {
 
     if (numero) {
       sources.push({
+        generateId: true,
         name: 'positions',
         type: 'geojson',
         data: adresseToPositionsGeoJson(numero)

--- a/lib/geojson.js
+++ b/lib/geojson.js
@@ -27,7 +27,6 @@ function numeroToFeature(numero) {
   const {type} = position
 
   const coords = getCoordinates(position)
-  const id = numero.cleInterop || Math.floor((Math.random() * 100) + 1)
   const properties = {
     ...numero,
     color: numero.idVoie ? randomColor({
@@ -38,8 +37,7 @@ function numeroToFeature(numero) {
   }
 
   return {
-    type: 'Point',
-    id,
+    type: 'Feature',
     geometry: {
       type: 'Point',
       coordinates: coords


### PR DESCRIPTION
Issues #713 et #577

- Suppression de la propriété id de la méthode `numeroToFeature `de `lib/geojson`
- Remplacement du type "Point" par "Feature" dans `lib/geojson`
- Ajout de la propriété `generateId` à la source liée aux numéros dans le hook `useSources`

*edit*

- Ajout de la propriété `generateId` à la source liée aux positions dans le hook `useSources`

