### PR TITLE
Correction du bug de redirection à la sélection d’un numéro depuis explore

### DIFF
--- a/components/explorer/voie/map-container.js
+++ b/components/explorer/voie/map-container.js
@@ -15,7 +15,7 @@ const MapContainer = ({voie, addresses, numero, onSelect}) => {
 
   const selectAddress = feature => {
     const numero = feature ? feature.properties.numero : null
-    const suffixe = feature ? feature.properties.suffixe : null
+    const suffixe = feature && feature.properties.suffixe !== 'null' ? suffixe : null
     onSelect(numero, suffixe)
   }
 


### PR DESCRIPTION
Issue #712 

Correction de l'erreur qui ajoutait "null" aux numéros sans suffixe au clique depuis la carte

- Modification de la condition qui renvoie `null` au lieu de la string `"null"` quand il n'y a pas de suffixe