### PR TITLE
Correction de la taille du logo des BAL

### DIFF
--- a/components/bases-locales/bases-adresse-locales/dataset/header.js
+++ b/components/bases-locales/bases-adresse-locales/dataset/header.js
@@ -36,7 +36,7 @@ class Header extends React.Component {
             </Info>
           )}
         </div>
-        {logo && <Image width={240} height={140} src={logo} alt={`${name}-logo`} />}
+        {logo && <Image objectFit='contain' width={240} height={140} src={logo} alt={`${name}-logo`} />}
 
         <style jsx>{`
           .head {


### PR DESCRIPTION
- Ajout de la propriété `objectFit ` avec la valeur `contain` dans le composant `Image`

*captures :*
- avant
![calvados-before](https://user-images.githubusercontent.com/45098730/100993961-55ed3280-3556-11eb-85d4-bffddee7dbef.PNG)

- après 
![calvados-after](https://user-images.githubusercontent.com/45098730/100993985-5f769a80-3556-11eb-947b-dfe503c71d9b.PNG)


*https://adresse.data.gouv.fr/bases-locales/jeux-de-donnees/5fb62ef835244cf29665cca7*