### PR TITLE
Désactivation du bouton "recentrer" en fonction du contexte

### DIFF
--- a/components/mapbox/ban-map/index.js
+++ b/components/mapbox/ban-map/index.js
@@ -90,14 +90,21 @@ function BanMap({map, isSourceLoaded, popup, address, setSources, setLayers, onS
   }, [address, isCenterControlDisabled, map])
 
   const isAddressVisible = useCallback(() => {
-    const {lng, lat} = map.getCenter()
+    const bounds = map.getBounds()
+    const currentBBox = [
+      bounds._sw.lng,
+      bounds._sw.lat,
+      bounds._ne.lng,
+      bounds._ne.lat
+    ]
+
     const currentZoom = map.getZoom()
-    const isCurrentCenterInBBox = isPointInBBox([lng, lat], address.displayBBox)
+    const isAddressInCurrentBBox = isPointInBBox(address.displayBBox, currentBBox)
 
     const maxRange = currentZoom < ZOOM_RANGE[address.type].max
     const minRange = currentZoom > ZOOM_RANGE[address.type].min
 
-    return isCurrentCenterInBBox && maxRange && minRange
+    return isAddressInCurrentBBox && maxRange && minRange
   }, [map, address])
 
   useEffect(() => {

--- a/components/mapbox/ban-map/index.js
+++ b/components/mapbox/ban-map/index.js
@@ -59,7 +59,9 @@ function BanMap({map, isSourceLoaded, popup, address, setSources, setLayers, onS
 
   const centerAddress = () => {
     if (address) {
-      map.fitBounds(address.displayBBox)
+      map.fitBounds(address.displayBBox, {
+        padding: 30
+      })
     }
   }
 

--- a/components/mapbox/ban-map/index.js
+++ b/components/mapbox/ban-map/index.js
@@ -67,7 +67,7 @@ function BanMap({map, isSourceLoaded, popup, address, setSources, setLayers, onS
     }
   }, [address, isCenterControlDisabled, map])
 
-  const hasVisibleRenderedFeatures = useCallback(() => {
+  const isAddressVisible = useCallback(() => {
     const featuresQuery = map.queryRenderedFeatures({layers: [
       adresseCircleLayer.id,
       adresseLabelLayer.id,
@@ -76,15 +76,7 @@ function BanMap({map, isSourceLoaded, popup, address, setSources, setLayers, onS
       toponymeLayer.id
     ]})
 
-    const hasFeatures = featuresQuery.some(({id}) => {
-      if (address) {
-        return id === address.id
-      }
-
-      return false
-    })
-
-    setIsCenterControlDisabled(address ? hasFeatures : true)
+    return featuresQuery.some(({id}) => id === address.id)
   }, [map, address])
 
   useEffect(() => {

--- a/components/mapbox/ban-map/index.js
+++ b/components/mapbox/ban-map/index.js
@@ -86,14 +86,28 @@ function BanMap({map, isSourceLoaded, popup, address, setSources, setLayers, onS
   }, [isSourceLoaded, address, hasVisibleRenderedFeatures])
 
   useEffect(() => {
-    if (!address) {
+    if (address) {
+      const isVisible = isAddressVisible()
+      setIsCenterControlDisabled(isVisible)
+    } else {
       setIsCenterControlDisabled(true)
     }
+  }, [address, isAddressVisible])
 
-    map.on('moveend', () => {
-      hasVisibleRenderedFeatures()
-    })
-  }, [map, address, hasVisibleRenderedFeatures, isCenterControlDisabled])
+  useEffect(() => {
+    if (address) {
+      map.on('moveend', () => {
+        const isVisible = isAddressVisible()
+        setIsCenterControlDisabled(isVisible)
+      })
+
+      return () => {
+        map.off('moveend', isAddressVisible)
+      }
+    }
+
+    setIsCenterControlDisabled(true)
+  }, [map, address, isAddressVisible])
 
   useEffect(() => {
     map.on('mousemove', 'adresse', onHover)

--- a/components/mapbox/ban-map/index.js
+++ b/components/mapbox/ban-map/index.js
@@ -59,13 +59,13 @@ function BanMap({map, isSourceLoaded, popup, address, setSources, setLayers, onS
     cb(feature.properties)
   }
 
-  const centerAddress = () => {
+  const centerAddress = useCallback(() => {
     if (address && !isCenterControlDisabled) {
       map.fitBounds(address.displayBBox, {
         padding: 30
       })
     }
-  }
+  }, [address, isCenterControlDisabled, map])
 
   const hasVisibleRenderedFeatures = useCallback(() => {
     const featuresQuery = map.queryRenderedFeatures({layers: [

--- a/components/mapbox/ban-map/index.js
+++ b/components/mapbox/ban-map/index.js
@@ -106,10 +106,10 @@ function BanMap({map, isSourceLoaded, popup, address, setSources, setLayers, onS
     const currentZoom = map.getZoom()
     const isAddressInCurrentBBox = isPointInBBox(address.displayBBox, currentBBox)
 
-    const maxRange = currentZoom < ZOOM_RANGE[address.type].max
-    const minRange = currentZoom > ZOOM_RANGE[address.type].min
+    const isZoomSmallerThanMax = currentZoom <= ZOOM_RANGE[address.type].max
+    const isZoomGreaterThanMin = currentZoom >= ZOOM_RANGE[address.type].min
 
-    return isAddressInCurrentBBox && maxRange && minRange
+    return isAddressInCurrentBBox && isZoomSmallerThanMax && isZoomGreaterThanMin
   }, [map, address])
 
   useEffect(() => {

--- a/components/mapbox/ban-map/index.js
+++ b/components/mapbox/ban-map/index.js
@@ -117,21 +117,6 @@ function BanMap({map, isSourceLoaded, popup, address, setSources, setLayers, onS
   }, [address, isAddressVisible])
 
   useEffect(() => {
-    if (address) {
-      map.on('moveend', () => {
-        const isVisible = isAddressVisible()
-        setIsCenterControlDisabled(isVisible)
-      })
-
-      return () => {
-        map.off('moveend', isAddressVisible)
-      }
-    }
-
-    setIsCenterControlDisabled(true)
-  }, [map, address, isAddressVisible])
-
-  useEffect(() => {
     map.on('mousemove', 'adresse', onHover)
     map.on('mousemove', 'adresse-label', onHover)
     map.on('mousemove', 'voie', onHover)
@@ -146,6 +131,19 @@ function BanMap({map, isSourceLoaded, popup, address, setSources, setLayers, onS
     map.on('click', 'adresse-label', e => handleClick(e, onSelect))
     map.on('click', 'voie', e => handleClick(e, onSelect))
     map.on('click', 'toponyme', e => handleClick(e, onSelect))
+
+    if (address) {
+      map.on('moveend', () => {
+        const isVisible = isAddressVisible()
+        setIsCenterControlDisabled(isVisible)
+      })
+
+      return () => {
+        map.off('moveend', isAddressVisible)
+      }
+    }
+
+    setIsCenterControlDisabled(true)
 
     return () => {
       map.off('mousemove', 'adresse', onHover)
@@ -165,7 +163,7 @@ function BanMap({map, isSourceLoaded, popup, address, setSources, setLayers, onS
     }
 
     // No dependency in order to mock a didMount and avoid duplicating events.
-  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [isAddressVisible]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     setSources([{

--- a/components/mapbox/ban-map/index.js
+++ b/components/mapbox/ban-map/index.js
@@ -12,19 +12,24 @@ import {forEach} from 'lodash'
 let hoveredVoieId = null
 
 const SOURCES = ['adresses', 'toponymes']
+const MAX_ZOOM = 19 // Zoom maximum de la carte
 
 const ZOOM_RANGE = {
   commune: {
-    min: 12,
-    max: 13
+    min: adresseCircleLayer.minzoom,
+    max: MAX_ZOOM
   },
   voie: {
-    min: 15,
-    max: 18
+    min: voieLayer.minzoom,
+    max: voieLayer.maxzoom
   },
   numero: {
-    min: 17,
-    max: 20
+    min: adresseLabelLayer.minzoom,
+    max: MAX_ZOOM
+  },
+  'lieu-dit': {
+    min: toponymeLayer.minzoom,
+    max: toponymeLayer.maxzoom
   }
 }
 

--- a/components/mapbox/center-control.js
+++ b/components/mapbox/center-control.js
@@ -5,20 +5,34 @@ import {Crosshair} from 'react-feather'
 function CenterControl({isDisabled, handleClick}) {
   return (
     <div>
-      <a title='Recentrer la carte sur l’adresse' onClick={handleClick}>
-        <div className='mapboxgl-ctrl-group mapboxgl-ctrl center-control'>
-          <Crosshair size={18} color={isDisabled ? '#cdcdcd' : 'black'} />
-        </div>
-      </a>
+      <button
+        disabled={isDisabled}
+        type='button'
+        className='mapboxgl-ctrl-group mapboxgl-ctrl center-control'
+        title='Recentrer la carte sur l’adresse'
+        onClick={handleClick}
+      >
+        <Crosshair size={18} color={isDisabled ? '#cdcdcd' : 'black'} />
+      </button>
 
       <style jsx>{`
         .center-control {
           position: absolute;
-          padding: 0.3em 0.3em 0 0.3em;
+          box-shadow: none;
+          border: 2px solid #dcd8d5;
           z-index: 2;
-          right: 10px;
+          padding: 4px 5px 2px 5px;
+          right: 8px;
           top: 80px;
           cursor: ${isDisabled ? 'not-allowed' : 'pointer'};
+        }
+
+        .center-control:focus {
+          outline: none;
+        }
+
+        .center-control:not(:disabled):hover {
+          background-color: #f2f2f2
         }
       `}
       </style>

--- a/components/mapbox/center-control.js
+++ b/components/mapbox/center-control.js
@@ -2,12 +2,12 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import {Crosshair} from 'react-feather'
 
-function CenterControl({handleClick}) {
+function CenterControl({isDisabled, handleClick}) {
   return (
     <div>
       <a title='Recentrer la carte sur l’adresse' onClick={handleClick}>
         <div className='mapboxgl-ctrl-group mapboxgl-ctrl center-control'>
-          <Crosshair size={18} color='black' />
+          <Crosshair size={18} color={isDisabled ? '#cdcdcd' : 'black'} />
         </div>
       </a>
 
@@ -18,6 +18,7 @@ function CenterControl({handleClick}) {
           z-index: 2;
           right: 10px;
           top: 80px;
+          cursor: ${isDisabled ? 'not-allowed' : 'pointer'};
         }
       `}
       </style>
@@ -26,7 +27,12 @@ function CenterControl({handleClick}) {
 }
 
 CenterControl.propTypes = {
-  handleClick: PropTypes.func.isRequired
+  handleClick: PropTypes.func.isRequired,
+  isDisabled: PropTypes.bool
+}
+
+CenterControl.defaultProps = {
+  isDisabled: false
 }
 
 export default CenterControl

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@etalab/project-legal": "^0.4.0",
     "@turf/bbox": "^6.0.1",
     "@turf/bbox-polygon": "^6.2.0",
-    "@turf/boolean-point-in-polygon": "^6.2.0",
+    "@turf/boolean-contains": "^6.2.0",
     "blob-to-buffer": "^1.2.9",
     "chart.js": "^2.9.4",
     "compression": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "@etalab/bal": "^0.24.0",
     "@etalab/project-legal": "^0.4.0",
     "@turf/bbox": "^6.0.1",
+    "@turf/bbox-polygon": "^6.2.0",
+    "@turf/boolean-point-in-polygon": "^6.2.0",
     "blob-to-buffer": "^1.2.9",
     "chart.js": "^2.9.4",
     "compression": "^1.7.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -449,6 +449,13 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@turf/bbox-polygon@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@turf/bbox-polygon/-/bbox-polygon-6.2.0.tgz#53f87b2865949d01ab78752510a649e638bf5cd1"
+  integrity sha512-07madHnOzuB6XYeHVCEyYbg7Wta1tFkbGZ6zXUXIjCoq/eVXYtBoh8Q2uyFRuUhAODwBVYCA2iSNk6bsMPJhxw==
+  dependencies:
+    "@turf/helpers" "^6.2.0"
+
 "@turf/bbox@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@turf/bbox/-/bbox-6.0.1.tgz#b966075771475940ee1c16be2a12cf389e6e923a"
@@ -457,10 +464,25 @@
     "@turf/helpers" "6.x"
     "@turf/meta" "6.x"
 
-"@turf/helpers@6.x":
-  version "6.1.4"
-  resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-6.1.4.tgz#d6fd7ebe6782dd9c87dca5559bda5c48ae4c3836"
-  integrity sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g==
+"@turf/boolean-point-in-polygon@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-6.2.0.tgz#b9f4984535a4d0cb98959ff6e402b82df14f3015"
+  integrity sha512-oYL8nuz+MeIEuJgX8IhnQstLNmqU6cARNd8Wgkn5FgWmMGJn+7j4ajMY/SPAmBUq4il45VO3X03lxftxTCCsog==
+  dependencies:
+    "@turf/helpers" "^6.2.0"
+    "@turf/invariant" "^6.2.0"
+
+"@turf/helpers@6.x", "@turf/helpers@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-6.2.0.tgz#dc770ce3b35b230f6a661824f3f87591378e379b"
+  integrity sha512-ANcZ0LFpnrza52y3um8KXgbpF1l7qmJXEqY1Bv5RovdQH+kUvMrZsb4SO3q4VH4eQqlsxDLxxXl7hkjjFbDtHg==
+
+"@turf/invariant@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-6.2.0.tgz#91c732b7c53e95afdbea944be3316bb8afd6a118"
+  integrity sha512-kyhKp3rW1tDe78xFkgq9+zC6dkBJyvEwP4HNNculIXRyN4Xoo7GJECE1wPyujQppj3Lmu63GtE6B68coEZ0Gqw==
+  dependencies:
+    "@turf/helpers" "^6.2.0"
 
 "@turf/meta@6.x":
   version "6.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -464,10 +464,37 @@
     "@turf/helpers" "6.x"
     "@turf/meta" "6.x"
 
+"@turf/bbox@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@turf/bbox/-/bbox-6.2.0.tgz#ae75ab6b111478863dd34c4e63dbb36e613e6854"
+  integrity sha512-8KR//ruA/hhCvDiBzxBTUJ/G3hm9+tuCyeZA81hvdsooDpeq0PK/jSJjlwYjS//UK5c2deBeNNJx7NvL/PLEwg==
+  dependencies:
+    "@turf/helpers" "^6.2.0"
+    "@turf/meta" "^6.2.0"
+
+"@turf/boolean-contains@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-contains/-/boolean-contains-6.2.0.tgz#e1143227558eb4bd684502557b24f089d915eba9"
+  integrity sha512-EVB8VTbLxo632KvtxwYB9oQ4HDZpGx3v9dURkFvD7HeevIgCC/MYlOQ66eW8JQMcThZaWtep1EZpA+zxH/VL1g==
+  dependencies:
+    "@turf/bbox" "^6.2.0"
+    "@turf/boolean-point-in-polygon" "^6.2.0"
+    "@turf/boolean-point-on-line" "^6.2.0"
+    "@turf/helpers" "^6.2.0"
+    "@turf/invariant" "^6.2.0"
+
 "@turf/boolean-point-in-polygon@^6.2.0":
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-6.2.0.tgz#b9f4984535a4d0cb98959ff6e402b82df14f3015"
   integrity sha512-oYL8nuz+MeIEuJgX8IhnQstLNmqU6cARNd8Wgkn5FgWmMGJn+7j4ajMY/SPAmBUq4il45VO3X03lxftxTCCsog==
+  dependencies:
+    "@turf/helpers" "^6.2.0"
+    "@turf/invariant" "^6.2.0"
+
+"@turf/boolean-point-on-line@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-point-on-line/-/boolean-point-on-line-6.2.0.tgz#1c75fa72042077249b8716c77a0e502a016517f9"
+  integrity sha512-vZ2tEH4TK0i62fRBW12WNK2le70Y9VG33EIze9RvDCf2JQ2qpnU4XjZH3zcVmfQcZ537dZ2kgsDTIVA9yqgG2A==
   dependencies:
     "@turf/helpers" "^6.2.0"
     "@turf/invariant" "^6.2.0"
@@ -490,6 +517,13 @@
   integrity sha512-VA7HJkx7qF1l3+GNGkDVn2oXy4+QoLP6LktXAaZKjuT1JI0YESat7quUkbCMy4zP9lAUuvS4YMslLyTtr919FA==
   dependencies:
     "@turf/helpers" "6.x"
+
+"@turf/meta@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-6.2.0.tgz#a225477fd8b5a4166d98e2e70cc4ed843db0f48d"
+  integrity sha512-8bM69hzRYKNfpZ+cyLxXZLw1IqCxm3cBcyEkVBHROFsQJb1o1Ghv2cd4iCSIuvkc1xSWD+qQvUjYr40XSNsyOQ==
+  dependencies:
+    "@turf/helpers" "^6.2.0"
 
 "@types/color-name@^1.1.1":
   version "1.1.1"


### PR DESCRIPTION
- Désactivation du bouton "recentrer" :
  - quand les propriétés de l'adresse sélectionnée ne sont pas visibles
  - quand aucune adresse n'est sélectionnée
- Ajout d'un `padding` au recentrage. Permet d'être au même `bound` que lors de la sélection d'une adresse.

*capture vidéo*

https://user-images.githubusercontent.com/45098730/104718494-3e938e80-572b-11eb-9f86-8855974c0314.mp4
