### PR TITLE
Information supplémentaire après la publication

### DIFF
--- a/components/bases-locales/publication/published.js
+++ b/components/bases-locales/publication/published.js
@@ -1,46 +1,117 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import Link from 'next/link'
+import {Map} from 'react-feather'
 
 import theme from '@/styles/theme'
 
 import ButtonLink from '@/components/button-link'
 
-const Published = React.memo(({publicationUrl}) => {
+const Published = React.memo(({_id, commune}) => {
   return (
     <div className='published'>
-      <h1>Votre Base Adresse Locale a bien été publiée !</h1>
-      <div className='valid'>✓</div>
-      {publicationUrl ?
-        <ButtonLink href={publicationUrl}>
-          Voir les adresses
-        </ButtonLink> : null}
+      <div className='header'>
+        <h1>Votre Base Adresse Locale a bien été publiée !</h1>
+        <div className='valid'>✓</div>
+      </div>
+
+      <div className='message-container'>
+        <section>
+          <h4>✨ Un réel bénéfice pour votre commune</h4>
+          <p>
+            Les adresses de votre commune sont <b>maintenant à jour</b> et viennent alimenter <b>les référentiels nationaux</b>.<br />{}
+            Il est désormais plus simple pour vos administrés d’être&nbsp;:
+            <ul>
+              <li>⚡️ déclarés auprès des fournisseurs d’eau et d’énergies</li>
+              <li>🖥 éligibles à la fibre</li>
+              <li>📦 livrés</li>
+              <li>🚑 ou même secourus</li>
+            </ul>
+          </p>
+        </section>
+
+        <section>
+          <h4>🔍 Où consulter vos adresses ?</h4>
+          <p>
+            Vos adresses seront intégrées à la Base Adresse Nationale et disponibles dans un délai de <b>24 heures</b>.<br />{}
+            Elles seront consultables directement depuis notre <Link href={`/base-adresse-nationale/${commune.code}`}><a>carte interactive</a></Link>.
+          </p>
+        </section>
+
+        <section>
+          <h4>🚀 Ne vous arrêtez pas en si bon chemin !</h4>
+          <p>
+            Si vous souhaitez <b>mettre à jour</b> vos adresses ou effecter des <b>corrections</b>, continuer simplement l‘édition de cette Base Adresse Locale.<br />{}
+            Les changements seront <b>enregistrés automatiquement</b> et transmis à la Base Adresse Nationale.
+          </p>
+
+          <div className='centered'>
+            <ButtonLink href={`https://mes-adresses.data.gouv.fr/${_id}/communes/${commune.code}?published=1`} isExternal>
+              Continuer l’amélioration de mes adresses <Map style={{marginLeft: '.5em', verticalAlign: 'middle'}} />
+            </ButtonLink>
+          </div>
+        </section>
+
+        <section>
+          <h4>🇫🇷 Vous n’êtes pas seul</h4>
+          <p>
+            <b>Tous les jours</b> de nouvelles Bases Adresse Locales viennent alimenter la Base Adresse Nationale comme vous venez de le faire.<br />{}
+            Découvrez l’état du <Link href='/bases-locales'><a>déploiement des Bases Adresse Locales</a></Link> à l’échelle nationale.
+          </p>
+        </section>
+      </div>
 
       <style jsx>{`
+        section {
+          margin: 3em 0;
+          padding: 0 1em;
+          text-align: center;
+        }
+
+        h4 {
+          margin: 0;
+        }
+
+        ul {
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+          list-style-type: none;
+        }
+
         .published {
+          background: ${theme.successBg};
+          padding: 2em;
+        }
+
+        .header {
           display: flex;
           flex-direction: column;
           align-items: center;
-          background: ${theme.successBg};
           color: ${theme.successBorder};
-          padding: 2em;
-          text-align: center;
         }
 
         .valid {
           border-radius: 100%;
           background: ${theme.successBorder};
-          margin: 1em;
           color: #fff;
-          width: 80px;
-          height: 80px;
+          width: 60px;
+          height: 60px;
           display: flex;
           align-items: center;
           justify-content: center;
-          font-size: -webkit-xxx-large;
+          font-size: xx-large;
         }
 
-        a {
-          color: ${theme.successBorder};
+        .message-container {
+          background-color: #fff;
+          margin: 1em 0;
+          padding: 1em;
+        }
+
+        .centered {
+          display: flex;
+          justify-content: center;
         }
       `}</style>
     </div>
@@ -48,7 +119,10 @@ const Published = React.memo(({publicationUrl}) => {
 })
 
 Published.propTypes = {
-  publicationUrl: PropTypes.string.isRequired
+  _id: PropTypes.string.isRequired,
+  commune: PropTypes.shape({
+    code: PropTypes.string.isRequired
+  }).isRequired
 }
 
 export default Published

--- a/pages/bases-locales/publication.js
+++ b/pages/bases-locales/publication.js
@@ -145,7 +145,7 @@ const PublicationPage = React.memo(({bal, submissionId}) => {
           )}
 
           {step === 5 && (
-            <Published publicationUrl={bal.publicationUrl} />
+            <Published {...bal} />
           )}
         </div>
       </Section>


### PR DESCRIPTION
Après la publication d'une Base Adresse Locale, l'utilisateur se retrouvait dans une page "impasse" confirmant simplement la publication de sa Base Adresse Locale. Cette page assez pauvre en terme de retour pour l'utilisateur est maintenant utilisée pour informer l'utilisateur sur les conséquences de sa publication mais aussi le guide et l'encourager à continuer l'adressage sur cette même Base Adresse Locale.


![publication](https://user-images.githubusercontent.com/7040549/106143289-de610b80-6172-11eb-91e7-b20fc1955d18.png)
