### PR TITLE
Correction d'une coquille concernant l'affichage du nombre de voie et de lieu-dit

### DIFF
--- a/components/base-adresse-nationale/addresses-list.js
+++ b/components/base-adresse-nationale/addresses-list.js
@@ -32,28 +32,32 @@ function AddressesList({title, subtitle, placeholder, addresses, getLabel, addre
           <h5>{title}</h5>
           <div>{subtitle}</div>
         </div>
-        <div className='search-input'>
-          <div className='search-icon'><Search size={18} /></div>
-          <input
-            type='text'
-            placeholder={placeholder || 'Recherche'}
-            value={input}
-            onChange={e => setInput(e.target.value)}
-          />
-          {isLoading && <div className='loading'><Loader size='small' /></div>}
-        </div>
+        {addresses.length > 0 && (
+          <div className='search-input'>
+            <div className='search-icon'><Search size={18} /></div>
+            <input
+              type='text'
+              placeholder={placeholder || 'Recherche'}
+              value={input}
+              onChange={e => setInput(e.target.value)}
+            />
+            {isLoading && <div className='loading'><Loader size='small' /></div>}
+          </div>
+        )}
       </div>
 
-      <div className='addresses-list'>
-        {filteredList.length > 0 ?
-          filteredList.map(address => (
-            <div key={address.id} className='address-list'>
-              {addressComponent(address)}
-            </div>
-          )) : (
-            <div className='no-result'>Aucun résultat</div>
-          )}
-      </div>
+      {addresses.length > 0 && (
+        <div className='addresses-list'>
+          {filteredList.length > 0 ?
+            filteredList.map(address => (
+              <div key={address.id} className='address-list'>
+                {addressComponent(address)}
+              </div>
+            )) : (
+              <div className='no-result'>Aucun résultat</div>
+            )}
+        </div>
+      )}
 
       <style jsx>{`
         .addresses {

--- a/components/base-adresse-nationale/commune/index.js
+++ b/components/base-adresse-nationale/commune/index.js
@@ -42,7 +42,7 @@ function Commune({nomCommune, codeCommune, region, departement, typeComposition,
 
       <AddressesList
         title='Voie de la commune'
-        subtitle={`${nbVoies} voies répertoriées`}
+        subtitle={nbVoies > 0 ? (nbVoies > 1 ? `${nbVoies} voies répertoriées` : '1 voie répertoriée') : 'Aucune voie répertoriée'}
         placeholder={`Rechercher une voie à ${nomCommune}`}
         addresses={orderBy(voies.filter(({type}) => type === 'voie'), 'nomVoie', 'asc')}
         getLabel={({nomVoie}) => nomVoie}
@@ -54,7 +54,7 @@ function Commune({nomCommune, codeCommune, region, departement, typeComposition,
       <div id='lieux-dits' className='lieux-dits-list'>
         <AddressesList
           title='Lieux-dits de la commune'
-          subtitle={nbLieuxDits > 1 ? `${nbLieuxDits} lieux-dits répertoriés` : '1 lieu-dit répertorié'}
+          subtitle={nbLieuxDits > 0 ? (nbLieuxDits > 1 ? `${nbLieuxDits} lieux-dits répertoriés` : '1 lieu-dit répertorié') : 'Aucun lieu-dit répertorié'}
           placeholder={`Rechercher un lieu-dit à ${nomCommune}`}
           addresses={orderBy(voies.filter(({type}) => type === 'lieu-dit'), 'nomVoie', 'asc')}
           getLabel={({nomVoie}) => nomVoie}


### PR DESCRIPTION
*avant*
![aboncourt-before](https://user-images.githubusercontent.com/45098730/106575884-d7ecde00-653c-11eb-97de-eddecf53b531.JPG)

*après*

![aboncourt-after](https://user-images.githubusercontent.com/45098730/106575878-d6231a80-653c-11eb-8705-19f7a45364cb.JPG)

_____

*edit commit [7d155b2 (Remove search bar when no address is available)](https://github.com/etalab/adresse.data.gouv.fr/commit/7d155b22993f155ae62bb7f285e9a97cf60ee99d)*
![remove-search-bar](https://user-images.githubusercontent.com/45098730/106582426-42ede300-6544-11eb-8463-9c7f1703f614.JPG)
