### PR TITLE
Add an id to map section in bases-locales

### DIFF
--- a/components/bases-locales/index.js
+++ b/components/bases-locales/index.js
@@ -125,7 +125,7 @@ const BasesLocales = React.memo(({datasets, stats}) => {
       </Section>
 
       <Section title='État du déploiement des Bases Adresses Locales'>
-        <div className='map-stats-container' id='anchor-dashboard'>
+        <div className='map-stats-container' id='map-stat'>
           <div className='stats'>
             <Counter
               value={stats.count}

--- a/components/bases-locales/index.js
+++ b/components/bases-locales/index.js
@@ -125,7 +125,7 @@ const BasesLocales = React.memo(({datasets, stats}) => {
       </Section>
 
       <Section title='État du déploiement des Bases Adresses Locales'>
-        <div className='map-stats-container'>
+        <div className='map-stats-container' id='anchor-dashboard'>
           <div className='stats'>
             <Counter
               value={stats.count}


### PR DESCRIPTION
This PR just add an ID to this section : 
![Capture d’écran 2021-03-18 à 11 54 42](https://user-images.githubusercontent.com/66621960/111615226-c3109500-87e0-11eb-9b30-93fc473bfbb3.png)

Allows to made a link to it on the dashboard page on mes-adresses
**PR related to this one https://github.com/etalab/editeur-bal/pull/318**