### PR TITLE
Affiche le lieu-dit / complément de nom

### DIFF
--- a/components/base-adresse-nationale/numero/index.js
+++ b/components/base-adresse-nationale/numero/index.js
@@ -6,7 +6,7 @@ import {getNumeroComplet} from '@/lib/ban'
 
 import Certification from '../certification'
 
-function Numero({numero, suffixe, sourcePosition, commune, voie, libelleAcheminement, codePostal, cleInterop}) {
+function Numero({numero, suffixe, lieuDitComplementNom, sourcePosition, commune, voie, libelleAcheminement, codePostal, cleInterop}) {
   return (
     <>
       <div className='heading'>
@@ -23,6 +23,9 @@ function Numero({numero, suffixe, sourcePosition, commune, voie, libelleAchemine
           />
         </div>
       </div>
+      {lieuDitComplementNom && (
+        <div>Lieu-dit : <b>{lieuDitComplementNom}</b></div>
+      )}
       <div>Code postal : <b>{codePostal}</b></div>
       <div>Libellé d’acheminement : <b>{libelleAcheminement}</b></div>
       <div style={{margin: '1.2em 0'}}>Clé d’interopérabilité : <b>{cleInterop}</b></div>
@@ -47,6 +50,7 @@ function Numero({numero, suffixe, sourcePosition, commune, voie, libelleAchemine
 Numero.propTypes = {
   numero: PropTypes.string.isRequired,
   suffixe: PropTypes.string,
+  lieuDitComplementNom: PropTypes.string,
   sourcePosition: PropTypes.string.isRequired,
   commune: PropTypes.shape({
     id: PropTypes.string.isRequired,

--- a/components/base-adresse-nationale/voie/numero.js
+++ b/components/base-adresse-nationale/voie/numero.js
@@ -48,7 +48,7 @@ Numero.propTypes = {
   id: PropTypes.string.isRequired,
   suffixe: PropTypes.string,
   numero: PropTypes.string.isRequired,
-  lieuDitComplementNom: PropTypes.string,
+  lieuDitComplementNom: PropTypes.string
 }
 
 export default Numero

--- a/components/base-adresse-nationale/voie/numero.js
+++ b/components/base-adresse-nationale/voie/numero.js
@@ -6,12 +6,12 @@ import theme from '@/styles/theme'
 
 import {getNumeroComplet} from '@/lib/ban'
 
-function Numero({id, numero, suffixe}) {
+function Numero({id, numero, suffixe, lieuDitComplementNom}) {
   return (
     <Link href={`/base-adresse-nationale?id=${id}`} as={`/base-adresse-nationale/${id}`}>
       <a>
         <div className='numero'>
-          <b>{getNumeroComplet({numero, suffixe})}</b>
+          <b>{getNumeroComplet({numero, suffixe})}</b> {lieuDitComplementNom}
         </div>
 
         <style jsx>{`
@@ -40,13 +40,15 @@ function Numero({id, numero, suffixe}) {
 }
 
 Numero.propTypes = {
-  suffixe: null
+  suffixe: null,
+  lieuDitComplementNom: null
 }
 
 Numero.propTypes = {
   id: PropTypes.string.isRequired,
   suffixe: PropTypes.string,
-  numero: PropTypes.string.isRequired
+  numero: PropTypes.string.isRequired,
+  lieuDitComplementNom: PropTypes.string,
 }
 
 export default Numero

--- a/components/mapbox/ban-map/popups.js
+++ b/components/mapbox/ban-map/popups.js
@@ -5,14 +5,14 @@ import Tag from '@/components/tag'
 
 import {sources} from './layers'
 
-function popupNumero({numero, suffixe, nomVoie, nomCommune, codeCommune, sourcePosition, sourceNomVoie}) {
+function popupNumero({numero, suffixe, lieuDitComplementNom, nomVoie, nomCommune, codeCommune, sourcePosition, sourceNomVoie}) {
   const position = sources[sourcePosition]
   const nom = sources[sourceNomVoie]
 
   return renderToString(
     <div>
       <div className='heading'>
-        <b>{numero}{suffixe} {nomVoie}</b>
+        <b>{numero}{suffixe} {nomVoie} {lieuDitComplementNom ? `(${lieuDitComplementNom})` : ''}</b>
         <Tag type='numero' />
       </div>
       <div>{nomCommune} {codeCommune}</div>


### PR DESCRIPTION
Correspond au champ `lieudit_complement_nom` du format BAL 1.2.

L'information est affiché dans le listing des numéros :

<img width="455" alt="Capture d’écran 2021-03-22 à 23 14 11" src="https://user-images.githubusercontent.com/1231232/112066018-ef703c80-8b65-11eb-9d87-579612be01e5.png">

Dans le panneau d'infos du numéro :

<img width="437" alt="Capture d’écran 2021-03-22 à 23 17 18" src="https://user-images.githubusercontent.com/1231232/112066049-fa2ad180-8b65-11eb-98ce-7bdbe5828ddf.png">

Et dans la popup du numéro sur la carte :

<img width="333" alt="Capture d’écran 2021-03-22 à 23 21 18" src="https://user-images.githubusercontent.com/1231232/112066070-01ea7600-8b66-11eb-9f7b-e0bbcc403702.png">

Un peu de CSS ne serait pas de refus ;)