### PR TITLE
Utiliser les couleurs de la charte graphique et modifications bordures

### DIFF
--- a/components/bases-locales/charte/partner.js
+++ b/components/bases-locales/charte/partner.js
@@ -3,6 +3,7 @@ import React, {useState} from 'react'
 import Image from 'next/image'
 import PropTypes from 'prop-types'
 
+import colors from '@/styles/colors'
 import {ChevronDown, ChevronUp} from 'react-feather'
 
 const formatService = service => {
@@ -39,9 +40,9 @@ function Partner({partnerInfos, isDetailed}) {
             )}
             <div className='chevron'>
               {isDisplay ? (
-                <ChevronUp size={18} color='rgba(10, 58, 231, 0.7)' />
+                <ChevronUp size={18} color={`${colors.lightBlue}`} />
               ) : (
-                <ChevronDown size={18} color='rgba(10, 58, 231, 0.7)' />
+                <ChevronDown size={18} color={`${colors.lightBlue}`} />
               )}
             </div>
           </button>
@@ -88,7 +89,7 @@ function Partner({partnerInfos, isDetailed}) {
           }
 
           a {
-            color: rgb(0,0,0,0.7)
+            color: ${colors.darkGrey};
           }
 
           .display-info-container {
@@ -96,7 +97,7 @@ function Partner({partnerInfos, isDetailed}) {
             display: grid;
             grid-template-rows: 1fr 0.5fr;
             font-style: italic;
-            color: rgba(0, 0, 0, 0.66);
+            color: ${colors.darkerGrey};
           }
 
           .button-container {
@@ -107,17 +108,12 @@ function Partner({partnerInfos, isDetailed}) {
             justify-items: self-start;
             border-style: none;
             background-color: transparent;
+            border-bottom: 1px solid ${colors.lightBlue};
           }
 
           .chevron {
             justify-self: end;
             padding-top: 0.4em;
-          }
-
-          .separator {
-            width: 100%;
-            height: 0;
-            border: 1px solid rgba(10, 58, 231, 0.17);
           }
 
           .infos-container {
@@ -131,7 +127,7 @@ function Partner({partnerInfos, isDetailed}) {
 
           p {
             font-style: italic;
-            color:rgb(0,0,0,0.6)
+            color:${colors.darkGrey};
           }
 
           .title {
@@ -139,14 +135,14 @@ function Partner({partnerInfos, isDetailed}) {
             font-weight: normal;
             margin: 0;
             font-style: italic;
-            color: rgba(0, 0, 0, 0.82);
+            color: ${colors.almostBlack};
           }
 
           .perimeter p, .services p {
             margin: 0;
             font-size: 0.9em;
             font-weight: bold;
-            color: rgba(0, 0, 0, 0.8);
+            color: ${colors.almostBlack};
           }
 
           .hidden {

--- a/components/temoignage.js
+++ b/components/temoignage.js
@@ -1,7 +1,8 @@
 import React from 'react'
 import Image from 'next/image'
-
 import PropTypes from 'prop-types'
+
+import colors from '@/styles/colors'
 
 function Temoignage({testimony}) {
   const {title, picture, alt, preview, articleUrl, date} = testimony
@@ -46,7 +47,7 @@ function Temoignage({testimony}) {
 
           .temoignage-image-container {
             position: relative;
-            box-shadow: 38px 24px 50px -21px rgba(119,117,117,0.30);
+            box-shadow: 38px 24px 50px -21px ${colors.lightGrey};
           }
 
          .date-container {
@@ -59,11 +60,7 @@ function Temoignage({testimony}) {
               margin: 0;
               font-size: 0.8em;
               font-style: italic;
-          }
-
-          .separator {
-            border: 1px solid #2053B3;
-            width: 100%;
+              border-bottom: 2px solid ${colors.blue};
           }
 
           .preview {


### PR DESCRIPTION
- Supprimer les div servant de séparateurs et remplacer par des border-bottom
- Utiliser les couleurs établies dans la charte graphique

<img width="1125" alt="Capture d’écran 2021-03-30 à 16 20 15" src="https://user-images.githubusercontent.com/66621960/113004405-dffb7f80-9173-11eb-8b69-c31c4ee8cab2.png">
<img width="1118" alt="Capture d’écran 2021-03-30 à 16 20 24" src="https://user-images.githubusercontent.com/66621960/113004438-e558ca00-9173-11eb-8452-22004ed0046b.png">
