### PR TITLE
Correction erreur 500 quand une adresse n'a pas de position

### DIFF
--- a/components/base-adresse-nationale/voie/index.js
+++ b/components/base-adresse-nationale/voie/index.js
@@ -9,8 +9,9 @@ import Tag from '@/components/tag'
 
 import AddressesList from '../addresses-list'
 import Numero from './numero'
+import Notification from '@/components/notification'
 
-function Voie({type, nomVoie, commune, numeros, nbNumeros}) {
+function Voie({type, nomVoie, commune, numeros, displayBBox, nbNumeros}) {
   const isToponyme = type === 'lieu-dit'
   const {region, departement} = commune
 
@@ -24,6 +25,9 @@ function Voie({type, nomVoie, commune, numeros, nbNumeros}) {
         )}
         <div className='number-of-numeros'>{nbNumeros > 0 ? (nbNumeros > 1 ? `${nbNumeros} numéros répertoriés` : '1 numéro répertorié') : 'Aucun numéros répertorié'}</div>
       </div>
+      {!displayBBox && (
+        <Notification type='warning' message='Aucune position n’est connue pour cette adresse, elle ne peut donc pas être affichée sur la carte.' />
+      )}
       {isToponyme ? (
         <Tag type='lieu-dit' />
       ) : (
@@ -72,7 +76,8 @@ function Voie({type, nomVoie, commune, numeros, nbNumeros}) {
 Voie.propTypes = {
   commune: null,
   numeros: null,
-  nbNumeros: null
+  nbNumeros: null,
+  displayBBox: null
 }
 
 Voie.propTypes = {
@@ -85,6 +90,7 @@ Voie.propTypes = {
     region: PropTypes.object,
     departement: PropTypes.object
   }),
+  displayBBox: PropTypes.array,
   nbNumeros: PropTypes.number,
   numeros: PropTypes.array
 }

--- a/components/mapbox/ban-map/index.js
+++ b/components/mapbox/ban-map/index.js
@@ -145,7 +145,7 @@ function BanMap({map, isSourceLoaded, popup, address, setSources, setLayers, onS
       ]
 
       const currentZoom = map.getZoom()
-      const isAddressInMapBBox = isFeatureContained(mapBBox, address.displayBBox)
+      const isAddressInMapBBox = address.displayBBox ? isFeatureContained(mapBBox, address.displayBBox) : false
 
       const isZoomSmallerThanMax = currentZoom <= ZOOM_RANGE[address.type].max
       const isZoomGreaterThanMin = currentZoom >= ZOOM_RANGE[address.type].min
@@ -288,7 +288,7 @@ BanMap.propTypes = {
     id: PropTypes.string.isRequired,
     type: PropTypes.string.isRequired,
     position: PropTypes.object,
-    displayBBox: PropTypes.array.isRequired
+    displayBBox: PropTypes.array
   }),
   map: PropTypes.object.isRequired,
   isSourceLoaded: PropTypes.bool,

--- a/pages/base-adresse-nationale.js
+++ b/pages/base-adresse-nationale.js
@@ -115,7 +115,7 @@ BaseAdresseNationale.propTypes = {
     voie: PropTypes.shape({
       nomVoie: PropTypes.string
     }),
-    displayBBox: PropTypes.array.isRequired
+    displayBBox: PropTypes.array
   })
 }
 


### PR DESCRIPTION
## Problème
Certaines adresses comme https://adresse.data.gouv.fr/base-adresse-nationale/05001#11.07/44.7721/6.9715 provoque une `erreur 500` car celles-ci ne possède pas de position à afficher sur la carte.

## Correction
- Conditionne le calcule du fitbound à la présence de la valeur `displayBBox`
- Affiche un message d'avertissement afin de renseigné l'utilisateur sur l'absence de position de l'adresse sélectionnée

![Capture d’écran 2021-04-28 à 18 10 19](https://user-images.githubusercontent.com/7040549/116437141-6d062700-a84d-11eb-8fe6-cd32df91c080.png)