### PR TITLE
Changements mineurs sur la barre de recherche des partenaires

### DIFF
--- a/components/bases-locales/charte/search.js
+++ b/components/bases-locales/charte/search.js
@@ -71,7 +71,7 @@ function PartnersSearchbar() {
 
   return (
     <div style={{marginTop: '2em'}}>
-      <p className='searchbar-label'>Recherchez une structure de mutualisation sur votre territoire</p>
+      <p className='searchbar-label'>Recherchez un partenaire de la Charte de la Base Adresse Locale sur votre territoire</p>
       <SearchInput
         value={input}
         results={results}

--- a/components/bases-locales/charte/search.js
+++ b/components/bases-locales/charte/search.js
@@ -32,7 +32,9 @@ function PartnersSearchbar() {
     if (commune) {
       setFilteredPartners(partners.filter(({codeDepartement, isPerimeterFrance}) => (
         codeDepartement.includes(commune.codeDepartement) || isPerimeterFrance)
-      ).filter(({services}) => intersection(selectedTags, services).length === selectedTags.length))
+      ).filter(({services}) => intersection(selectedTags, services).length === selectedTags.length).sort((a, b) => {
+        return a.isPerimeterFrance - b.isPerimeterFrance
+      }))
     } else {
       setFilteredPartners([])
     }

--- a/components/bases-locales/charte/search.js
+++ b/components/bases-locales/charte/search.js
@@ -28,19 +28,23 @@ function PartnersSearchbar() {
     })
   }
 
-  const sortedPartners = partners.sort((a, b) => {
-    return a.isPerimeterFrance - b.isPerimeterFrance
-  })
+  const getAvailablePartners = useCallback((communeCodeDepartement, tags) => {
+    const filteredByPerimeter = partners.filter(({codeDepartement, isPerimeterFrance}) => (codeDepartement.includes(communeCodeDepartement) || isPerimeterFrance))
+    const filteredByTags = filteredByPerimeter.filter(({services}) => intersection(tags, services).length === tags.length)
+
+    return filteredByTags.sort((a, b) => {
+      return a.isPerimeterFrance - b.isPerimeterFrance
+    })
+  }, [])
 
   useEffect(() => {
     if (commune) {
-      setFilteredPartners(sortedPartners.filter(({codeDepartement, isPerimeterFrance}) => (
-        codeDepartement.includes(commune.codeDepartement) || isPerimeterFrance)
-      ).filter(({services}) => intersection(selectedTags, services).length === selectedTags.length))
+      const availablePartners = getAvailablePartners(commune.codeDepartement, selectedTags)
+      setFilteredPartners(availablePartners)
     } else {
       setFilteredPartners([])
     }
-  }, [selectedTags, sortedPartners, commune])
+  }, [selectedTags, getAvailablePartners, commune])
 
   useEffect(() => {
     setInput(commune ? commune.nom : '')

--- a/components/bases-locales/charte/search.js
+++ b/components/bases-locales/charte/search.js
@@ -28,17 +28,19 @@ function PartnersSearchbar() {
     })
   }
 
+  const sortedPartners = partners.sort((a, b) => {
+    return a.isPerimeterFrance - b.isPerimeterFrance
+  })
+
   useEffect(() => {
     if (commune) {
-      setFilteredPartners(partners.filter(({codeDepartement, isPerimeterFrance}) => (
+      setFilteredPartners(sortedPartners.filter(({codeDepartement, isPerimeterFrance}) => (
         codeDepartement.includes(commune.codeDepartement) || isPerimeterFrance)
-      ).filter(({services}) => intersection(selectedTags, services).length === selectedTags.length).sort((a, b) => {
-        return a.isPerimeterFrance - b.isPerimeterFrance
-      }))
+      ).filter(({services}) => intersection(selectedTags, services).length === selectedTags.length))
     } else {
       setFilteredPartners([])
     }
-  }, [selectedTags, commune])
+  }, [selectedTags, sortedPartners, commune])
 
   useEffect(() => {
     setInput(commune ? commune.nom : '')

--- a/partners.json
+++ b/partners.json
@@ -75,11 +75,10 @@
         ],
         "isPerimeterFrance": false,
         "services": [
-            "animation",
-            "acculturation",
+            "formation",
             "accompagnement technique",
-            "Réalisation de bases adresses locales aveyronnaise",
-            "diffusion"
+            "réalisation de bases adresses locales",
+            "mise à disposition d’outils mutualisés"
         ],
         "picture": "/images/logos/partners/smica.png",
         "height": 70,

--- a/partners.json
+++ b/partners.json
@@ -243,7 +243,7 @@
         ],
         "isPerimeterFrance": false,
         "services": [
-            "Mise à disposition d’outil mutualisé",
+            "mise à disposition d’outils mutualisés",
             "accompagnement technique",
             "réalisation de bases adresses locales"
         ],


### PR DESCRIPTION
- Rendre les hashtags plus généralisés
- Changement du label de la barre de recherche
- Trier les partenaires trouvé de manière à ce que ceux dont le périmètre d'action est élargi à la France entière (ex: Sogefi) apparaissent en dernier.
- Suppression d'un coquille gênant la génération de hashtags

<img width="1680" alt="Capture d’écran 2021-05-04 à 18 13 38" src="https://user-images.githubusercontent.com/66621960/117035314-75a2a580-ad04-11eb-943d-4cf10b1c1450.png">

