### PR TITLE
Correction de la fiche partenaire de la Communauté de Communes du Pont du Gard

### DIFF
--- a/partners.json
+++ b/partners.json
@@ -174,7 +174,7 @@
     },
     {
         "name": "Communauté de Communes du Pont du Gard",
-        "link": "https://www.atd16.fr/",
+        "link": "http://www.cc-pontdugard.fr",
         "infos": "La Communauté de Communes du Pont du Gard se compose de 17 communes, et s’est doté d’un SIG propre pour gérer et mettre à jour ses données géographiques.",
         "perimeter": "Communauté de Communes du Pont du Gard (17 communes du Gard)",
         "codeDepartement": [


### PR DESCRIPTION
Correction du lien vers le site de la Communauté de Communes du Pont du Gard
  - `https://www.atd16.fr` remplacé par `http://www.cc-pontdugard.fr`