### PR TITLE
Extension de la limite de la recherche à 7 résultats

### DIFF
--- a/components/ban-search.js
+++ b/components/ban-search.js
@@ -25,7 +25,7 @@ function BanSearch() {
 
   const handleSearch = useCallback(debounce(async input => {
     try {
-      const results = await search({q: input, limit: 10})
+      const results = await search({q: input, limit: 7})
       setResults(
         results.features
           .filter(({properties}) => !['75056', '13055', '69123'].includes(properties.id)) // Filter Paris, Marseille and Lyon

--- a/components/ban-search.js
+++ b/components/ban-search.js
@@ -29,7 +29,7 @@ function BanSearch() {
       setResults(
         results.features
           .filter(({properties}) => !['75056', '13055', '69123'].includes(properties.id)) // Filter Paris, Marseille and Lyon
-          .splice(0, 5) || []
+          .splice(0, 10) || []
       )
     } catch (err) {
       setError(err)

--- a/components/ban-search.js
+++ b/components/ban-search.js
@@ -25,7 +25,7 @@ function BanSearch() {
 
   const handleSearch = useCallback(debounce(async input => {
     try {
-      const results = await search({q: input})
+      const results = await search({q: input, limit: 10})
       setResults(
         results.features
           .filter(({properties}) => !['75056', '13055', '69123'].includes(properties.id)) // Filter Paris, Marseille and Lyon

--- a/components/ban-search.js
+++ b/components/ban-search.js
@@ -29,7 +29,6 @@ function BanSearch() {
       setResults(
         results.features
           .filter(({properties}) => !['75056', '13055', '69123'].includes(properties.id)) // Filter Paris, Marseille and Lyon
-          .splice(0, 10) || []
       )
     } catch (err) {
       setError(err)

--- a/components/search-input/render-addok.js
+++ b/components/search-input/render-addok.js
@@ -46,7 +46,7 @@ function renderItem(item, isHighlighted) {
           flex-flow: row;
           justify-content: space-between;
           align-items: center;
-          padding: 1em;
+          padding: 0.5em;
         }
 
         .item .item-label {

--- a/lib/api-adresse.js
+++ b/lib/api-adresse.js
@@ -24,7 +24,7 @@ async function _fetch(url) {
 
 export function search(args) {
   const {q, limit, lng, lat} = args
-  let url = `${API_ADRESSE}/search/?q=${encodeURIComponent(q)}&limit=10`
+  let url = `${API_ADRESSE}/search/?q=${encodeURIComponent(q)}`
 
   if (lng && lat) {
     url += `&lng=${lng}&lat=${lat}`

--- a/lib/api-adresse.js
+++ b/lib/api-adresse.js
@@ -23,11 +23,15 @@ async function _fetch(url) {
 }
 
 export function search(args) {
-  const {q, lng, lat} = args
+  const {q, limit, lng, lat} = args
   let url = `${API_ADRESSE}/search/?q=${encodeURIComponent(q)}&limit=10`
 
   if (lng && lat) {
     url += `&lng=${lng}&lat=${lat}`
+  }
+
+  if (limit) {
+    url += `&limit=${limit}`
   }
 
   return _fetch(url)

--- a/lib/api-adresse.js
+++ b/lib/api-adresse.js
@@ -24,7 +24,7 @@ async function _fetch(url) {
 
 export function search(args) {
   const {q, lng, lat} = args
-  let url = `${API_ADRESSE}/search/?q=${encodeURIComponent(q)}`
+  let url = `${API_ADRESSE}/search/?q=${encodeURIComponent(q)}&limit=10`
 
   if (lng && lat) {
     url += `&lng=${lng}&lat=${lat}`


### PR DESCRIPTION
## Context
Il arrive que certains utilisateurs ne trouvent pas l'adresse qu'ils recherchent à cause de la limitation à 5 résultats.

## Proposition
Augmenter à 7 le nombre de résultat afin d'augmenter les chances de satisfaire la demande utilisateur tout en évitant des requêtes trop importante et la surcharge visuel que pourrait résulter d'un trop grand nombre de résultats.

- *avant*
![before](https://user-images.githubusercontent.com/45098730/118507164-45103200-b72e-11eb-84a8-5daa47f346fb.png)

- *après*
![after](https://user-images.githubusercontent.com/45098730/118507187-4b9ea980-b72e-11eb-9540-197d5dabcc40.png)

- *edit : 7 résultats*
![7 results](https://user-images.githubusercontent.com/45098730/118656901-43f10a80-b7eb-11eb-991e-67a37d4ece34.png)

