### PR TITLE
Mise à jour de la fiche partenaire du département de l'Yonne

### DIFF
--- a/partners.json
+++ b/partners.json
@@ -254,7 +254,7 @@
     },
     {
         "name": "Département de l'Yonne",
-        "link": "https://www.yonne.fr/Territoire/Amenagement-numerique",
+        "link": "https://www.yonne.fr/Territoire/Amenagement-numerique/Fiabilisation-de-l-adressage",
         "infos": "Le Conseil Départemental de l'Yonne, pilote du Schéma Directeur Territorial d'Aménagement Numérique, accompagne ses territoires dans la fiabilisation de leur adressage en vue notamment du raccordement à la fibre. Suite à l'information globale des communes réalisée en avril, nous sommes à votre disposition pour vous accompagner dans la création de votre Base d'Adresse Locale. Contactez-nous sur ant@yonne.fr et retrouvez nous sur https://www.yonne.fr/Territoire/Amenagement-numerique.",
         "perimeter": "Yonne",
         "codeDepartement": [


### PR DESCRIPTION
- `https://www.yonne.fr/Territoire/Amenagement-numerique` remplacé par
- `https://www.yonne.fr/Territoire/Amenagement-numerique/Fiabilisation-de-l-adressage`