### PR TITLE
Changement du titre de la liste des lieux-dits quand celle-ci est vide

### DIFF
--- a/components/base-adresse-nationale/addresses-list.js
+++ b/components/base-adresse-nationale/addresses-list.js
@@ -32,7 +32,7 @@ function AddressesList({title, subtitle, placeholder, addresses, getLabel, addre
           <h5>{title}</h5>
           <div>{subtitle}</div>
         </div>
-        {addresses.length > 0 && (
+        {addresses.length > 0 ? (
           <div className='search-input'>
             <div className='search-icon'><Search size={18} /></div>
             <input
@@ -42,6 +42,10 @@ function AddressesList({title, subtitle, placeholder, addresses, getLabel, addre
               onChange={e => setInput(e.target.value)}
             />
             {isLoading && <div className='loading'><Loader size='small' /></div>}
+          </div>
+        ) : (
+          <div className='no-addresse'>
+            Aucune adresse
           </div>
         )}
       </div>
@@ -106,7 +110,7 @@ function AddressesList({title, subtitle, placeholder, addresses, getLabel, addre
           background-color: ${theme.backgroundGrey};
         }
 
-        .no-result {
+        .no-result, .no-addresse {
           text-align: center;
           margin: 1em;
           font-weight: bold;

--- a/components/base-adresse-nationale/commune/index.js
+++ b/components/base-adresse-nationale/commune/index.js
@@ -12,7 +12,6 @@ import Voie from './voie'
 
 function Commune({nomCommune, codeCommune, region, departement, typeComposition, voies, nbVoies, nbLieuxDits, nbNumeros, population, codesPostaux}) {
   const [activeTab, setActiveTab] = useState('VOIES')
-  const lieuxDits = voies.filter(({type}) => type === 'lieu-dit')
 
   return (
     <>
@@ -54,9 +53,9 @@ function Commune({nomCommune, codeCommune, region, departement, typeComposition,
         ) : (
           <div id='lieux-dits'>
             <AddressesList
-              title={lieuxDits.length > 0 ? 'Lieux-dits de la commune' : 'Aucun lieu-dit'}
+              title='Lieux-dits de la commune'
               placeholder={`Rechercher un lieu-dit à ${nomCommune}`}
-              addresses={orderBy(lieuxDits, 'nomVoie', 'asc')}
+              addresses={orderBy(voies.filter(({type}) => type === 'lieu-dit'), 'nomVoie', 'asc')}
               getLabel={({nomVoie}) => nomVoie}
               addressComponent={voie => (
                 <Voie {...voie} />

--- a/components/base-adresse-nationale/commune/index.js
+++ b/components/base-adresse-nationale/commune/index.js
@@ -12,6 +12,7 @@ import Voie from './voie'
 
 function Commune({nomCommune, codeCommune, region, departement, typeComposition, voies, nbVoies, nbLieuxDits, nbNumeros, population, codesPostaux}) {
   const [activeTab, setActiveTab] = useState('VOIES')
+  const lieuxDits = voies.filter(({type}) => type === 'lieu-dit')
 
   return (
     <>
@@ -53,9 +54,9 @@ function Commune({nomCommune, codeCommune, region, departement, typeComposition,
         ) : (
           <div id='lieux-dits'>
             <AddressesList
-              title='Lieux-dits de la commune'
+              title={lieuxDits.length > 0 ? 'Lieux-dits de la commune' : 'Aucun lieu-dit'}
               placeholder={`Rechercher un lieu-dit à ${nomCommune}`}
-              addresses={orderBy(voies.filter(({type}) => type === 'lieu-dit'), 'nomVoie', 'asc')}
+              addresses={orderBy(lieuxDits, 'nomVoie', 'asc')}
               getLabel={({nomVoie}) => nomVoie}
               addressComponent={voie => (
                 <Voie {...voie} />


### PR DESCRIPTION
resolves #753

- Affiche `Aucun lieu-dit` quand il n'y en a pas

![lieu-dit](https://user-images.githubusercontent.com/45098730/120777862-0b109f80-c526-11eb-8ab3-a9ca29ad075d.png)

*edit commit [34da968](https://github.com/etalab/adresse.data.gouv.fr/pull/820/commits/34da968a8cc55790628117068120d366d3577635)*

![no-addresse](https://user-images.githubusercontent.com/45098730/120810030-fb578200-c54a-11eb-80f9-6268e8e9107e.png)
