### PR TITLE
Ajout d'informations sur le nombre de lignes concernées par les erreurs/avertissements dans le validateur

### DIFF
--- a/components/bases-locales/validator/report/summary/issues-sumup.js
+++ b/components/bases-locales/validator/report/summary/issues-sumup.js
@@ -7,10 +7,6 @@ import theme from '@/styles/theme'
 
 import IssueRows from './issue-rows'
 
-const isFloatNumber = value => {
-  return value % 1 !== 0
-}
-
 function IssuesSumup({issues, issueType, totalRowsCount, handleSelect}) {
   const issuesRows = Object.keys(issues).map(issue => {
     return issues[issue]
@@ -21,7 +17,7 @@ function IssuesSumup({issues, issueType, totalRowsCount, handleSelect}) {
   const issuesGroupedByLine = groupBy(issuesFlatten, 'line')
   const issuesCount = Object.keys(issuesGroupedByLine).length
   const percentageIssues = (issuesCount * 100) / totalRowsCount
-  const percentageRounded = isFloatNumber(percentageIssues) ? percentageIssues.toFixed(2) : percentageIssues
+  const percentageRounded = Number.isInteger(percentageIssues) ? percentageIssues : percentageIssues.toFixed(2)
 
   return (
     <div className='issues-container'>

--- a/components/bases-locales/validator/report/summary/issues-sumup.js
+++ b/components/bases-locales/validator/report/summary/issues-sumup.js
@@ -23,7 +23,7 @@ function IssuesSumup({issues, issueType, totalRowsCount, handleSelect}) {
     <div className='issues-container'>
       <h4>
         {issuesRowsCount} {issueType === 'error' ? 'Erreur' : 'Avertissement'}{issuesRowsCount > 1 ? 's' : ''}
-        &nbsp;({issuesCount} ligne{issuesCount > 1 ? 's' : ''}) - {percentageRounded} %
+        &nbsp;({issuesCount} ligne{issuesCount > 1 ? 's' : ''}) {percentageRounded}%
         <div className={`summary-icon ${issueType}`}>
           {issueType === 'error' ? (
             <X style={{verticalAlign: 'bottom'}} />

--- a/components/bases-locales/validator/report/summary/issues-sumup.js
+++ b/components/bases-locales/validator/report/summary/issues-sumup.js
@@ -1,18 +1,33 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import {X, AlertTriangle} from 'react-feather'
+import {flattenDeep, groupBy} from 'lodash'
 
 import theme from '@/styles/theme'
 
 import IssueRows from './issue-rows'
 
+const isFloatNumber = value => {
+  return value % 1 !== 0
+}
+
 function IssuesSumup({issues, issueType, totalRowsCount, handleSelect}) {
-  const issuesCount = Object.keys(issues).length
+  const issuesRows = Object.keys(issues).map(issue => {
+    return issues[issue]
+  })
+
+  const issuesFlatten = flattenDeep(issuesRows)
+  const issuesRowsCount = issuesFlatten.length
+  const issuesGroupedByLine = groupBy(issuesFlatten, 'line')
+  const issuesCount = Object.keys(issuesGroupedByLine).length
+  const percentageIssues = (issuesCount * 100) / totalRowsCount
+  const percentageRounded = isFloatNumber(percentageIssues) ? percentageIssues.toFixed(2) : percentageIssues
 
   return (
     <div className='issues-container'>
       <h4>
-        {issuesCount} {issueType === 'error' ? 'Erreur' : 'Avertissement'}{issuesCount > 1 ? 's' : ''}
+        {issuesRowsCount} {issueType === 'error' ? 'Erreur' : 'Avertissement'}{issuesRowsCount > 1 ? 's' : ''}
+        &nbsp;({issuesCount} ligne{issuesCount > 1 ? 's' : ''}) - {percentageRounded} %
         <div className={`summary-icon ${issueType}`}>
           {issueType === 'error' ? (
             <X style={{verticalAlign: 'bottom'}} />


### PR DESCRIPTION
resolves #779 

*avant*
![validator-before](https://user-images.githubusercontent.com/45098730/121217327-06c7e780-c882-11eb-937b-fb97860d342a.png)

*après*
![validator-after](https://user-images.githubusercontent.com/45098730/121217348-0b8c9b80-c882-11eb-8193-6fa714699ffc.png)
____

*edit 09/06 (commit [cb0533a](https://github.com/etalab/adresse.data.gouv.fr/pull/824/commits/cb0533a5703184e60167e3992212325b6976999a))*
![fix-percentage-display](https://user-images.githubusercontent.com/45098730/121387530-06dfea00-c94b-11eb-8ac6-3d27f3aa01dc.png)
