### PR TITLE
Suppression de l'espace blanc en bas de l'image des guides

### DIFF
--- a/components/doc-download.js
+++ b/components/doc-download.js
@@ -43,6 +43,7 @@ function DocDownload({title, link, src, alt, isReverse, children}) {
         }
 
         .preview {
+          display: flex;
           margin: 1em;
           border: 1px solid ${theme.border};
         }


### PR DESCRIPTION
Avant :
![Capture d’écran 2021-06-23 à 15 45 30](https://user-images.githubusercontent.com/66621960/123108210-833df700-d43a-11eb-84ae-26f091df24fa.png)

Après :
![Capture d’écran 2021-06-23 à 15 45 41](https://user-images.githubusercontent.com/66621960/123108229-8802ab00-d43a-11eb-8eac-cc65076752d8.png)
