### PR TITLE
Corrige la taille par défaut des icônes du composant Certification

### DIFF
--- a/components/base-adresse-nationale/certification.js
+++ b/components/base-adresse-nationale/certification.js
@@ -65,7 +65,7 @@ function Certification({isCertified, certifiedMessage, notCertifiedMessage, icon
   )
 }
 
-Certification.propTypes = {
+Certification.defaultProps = {
   iconSize: 34
 }
 


### PR DESCRIPTION
- Fix typo : `Certification.propTypes` -> `Certification.defaultProps`

*avant*
![certification-before](https://user-images.githubusercontent.com/45098730/123121530-868ab000-d445-11eb-8d9e-6b684bb80128.png)

*après*
![certification-after](https://user-images.githubusercontent.com/45098730/123121566-8d192780-d445-11eb-8548-b790018dbb9f.png)

