### PR TITLE
Implémente la certification à l'adresse

### DIFF
--- a/components/base-adresse-nationale/commune/index.js
+++ b/components/base-adresse-nationale/commune/index.js
@@ -10,7 +10,7 @@ import Details from '@/components/base-adresse-nationale/commune/details'
 import Tabs from '@/components/base-adresse-nationale/commune/tabs'
 import Voie from './voie'
 
-function Commune({nomCommune, codeCommune, region, departement, typeComposition, voies, nbVoies, nbLieuxDits, nbNumeros, population, codesPostaux}) {
+function Commune({nomCommune, codeCommune, region, departement, nbNumerosCertifies, voies, nbVoies, nbLieuxDits, nbNumeros, population, codesPostaux}) {
   const [activeTab, setActiveTab] = useState('VOIES')
 
   return (
@@ -22,9 +22,9 @@ function Commune({nomCommune, codeCommune, region, departement, typeComposition,
         </div>
         <div style={{padding: '1em'}}>
           <Certification
-            isCertified={typeComposition === 'bal'}
-            certifiedMessage='Les adresses sont certifiées par la commune'
-            notCertifiedMessage='Les adresses ne sont pas certifiées par la commune'
+            isCertified={nbNumeros === nbNumerosCertifies}
+            certifiedMessage='Toutes les adresses sont certifiées par la commune'
+            notCertifiedMessage='Certaines adresses ne sont pas certifiées par la commune'
           />
         </div>
       </div>
@@ -95,6 +95,7 @@ Commune.propTypes = {
   nbVoies: PropTypes.number.isRequired,
   nbLieuxDits: PropTypes.number.isRequired,
   nbNumeros: PropTypes.number.isRequired,
+  nbNumerosCertifies: PropTypes.number.isRequired,
   region: PropTypes.shape({
     nom: PropTypes.string.isRequired
   }).isRequired,

--- a/components/base-adresse-nationale/numero/index.js
+++ b/components/base-adresse-nationale/numero/index.js
@@ -13,7 +13,7 @@ import CoordinatesCopy from './coordinates-copy'
 
 import DeviceContext from '@/contexts/device'
 
-function Numero({numero, suffixe, lieuDitComplementNom, sourcePosition, commune, voie, libelleAcheminement, parcelles, codePostal, cleInterop, lat, lon, isMobile}) {
+function Numero({numero, suffixe, lieuDitComplementNom, certifie, commune, voie, libelleAcheminement, parcelles, codePostal, cleInterop, lat, lon, isMobile}) {
   const {isSafariBrowser} = useContext(DeviceContext)
   const [copyError, setCopyError] = useState(null)
   const [isCopyAvailable, setIsCopyAvailable] = useState(true)
@@ -31,7 +31,7 @@ function Numero({numero, suffixe, lieuDitComplementNom, sourcePosition, commune,
         </div>
         <div style={{padding: '1em'}}>
           <Certification
-            isCertified={sourcePosition === 'bal'}
+            isCertified={certifie}
             certifiedMessage='Ce numéro est certifié par la commune'
             notCertifiedMessage='Ce numéro n’est pas certifié par la commune'
           />
@@ -127,7 +127,7 @@ Numero.propTypes = {
   numero: PropTypes.string.isRequired,
   suffixe: PropTypes.string,
   lieuDitComplementNom: PropTypes.string,
-  sourcePosition: PropTypes.string.isRequired,
+  certifie: PropTypes.bool.isRequired,
   parcelles: PropTypes.array.isRequired,
   commune: PropTypes.shape({
     id: PropTypes.string.isRequired,

--- a/components/mapbox/ban-map/layers.js
+++ b/components/mapbox/ban-map/layers.js
@@ -13,7 +13,7 @@ export const sources = {
 
 export const defaultLayerPaint = [
   'case',
-  ['==', ['get', 'sourcePosition'], 'bal'],
+  ['==', ['get', 'certifie'], true],
   theme.successBorder,
   theme.warningBorder
 ]

--- a/components/mapbox/ban-map/layers.js
+++ b/components/mapbox/ban-map/layers.js
@@ -13,7 +13,7 @@ export const sources = {
 
 export const defaultLayerPaint = [
   'case',
-  ['==', ['get', 'certifie'], true],
+  ['boolean', ['get', 'certifie'], true],
   theme.successBorder,
   theme.warningBorder
 ]


### PR DESCRIPTION
Avant cette PR la certification est globale à la commune, et dépend de si les adresses proviennent d'une BAL.

Cette PR ajoute la certification à l'adresse, en particulier pour les adresses issues du Guichet Adresse.

<img width="974" alt="Capture d’écran 2021-07-01 à 21 51 57" src="https://user-images.githubusercontent.com/1231232/124182006-93974700-dab6-11eb-87ff-84a4bfcee2d4.png">

<img width="455" alt="Capture d’écran 2021-07-01 à 21 52 21" src="https://user-images.githubusercontent.com/1231232/124182038-a14ccc80-dab6-11eb-88ec-c2df6437d1cf.png">
