### PR TITLE
Clarification des sources dans l'explorateur BAN

### DIFF
--- a/components/mapbox/ban-map/layers.js
+++ b/components/mapbox/ban-map/layers.js
@@ -6,7 +6,7 @@ export const sources = {
   ftth: {name: 'Opérateur THD', color: '#118571'},
   'insee-ril': {name: 'INSEE', color: '#a6611a'},
   'ign-api-gestion-ign': {name: 'IGN', color: '#455d7a'},
-  'ign-api-gestion-laposte': {name: 'La Poste', color: '#feffbf'},
+  'ign-api-gestion-laposte': {name: 'La Poste', color: '#fecd51'},
   'ign-api-gestion-sdis': {name: 'SDIS (Pompiers)', color: '#d7191c'},
   'ign-api-gestion-municipal_administration': {name: 'Guichet Adresse', color: '#7b3294'}
 }

--- a/components/mapbox/ban-map/layers.js
+++ b/components/mapbox/ban-map/layers.js
@@ -1,14 +1,14 @@
 import theme from '@/styles/theme'
 
 export const sources = {
-  bal: {name: 'Base Adresse Locale (Commune)', color: '#4dac26'},
-  cadastre: {name: 'Cadastre (DGFiP)', color: '#2c7bb6'},
-  ftth: {name: 'IPE (Arcep / Opérateurs)', color: '#118571'},
-  'insee-ril': {name: 'RIL(INSEE)', color: '#7b3294'},
-  'ign-api-gestion-ign': {name: 'BD TOPO (IGN)', color: '#fdae61'},
+  bal: {name: 'Base Adresse Locale', color: '#4dac26'},
+  cadastre: {name: 'Cadastre', color: '#2c7bb6'},
+  ftth: {name: 'Opérateur THD', color: '#118571'},
+  'insee-ril': {name: 'INSEE', color: '#a6611a'},
+  'ign-api-gestion-ign': {name: 'IGN', color: '#455d7a'},
   'ign-api-gestion-laposte': {name: 'La Poste', color: '#feffbf'},
   'ign-api-gestion-sdis': {name: 'SDIS (Pompiers)', color: '#d7191c'},
-  'ign-api-gestion-municipal_administration': {name: 'Guichet Adresse (Commune)', color: '#a6611a'}
+  'ign-api-gestion-municipal_administration': {name: 'Guichet Adresse', color: '#7b3294'}
 }
 
 export const defaultLayerPaint = [

--- a/components/mapbox/ban-map/popups.js
+++ b/components/mapbox/ban-map/popups.js
@@ -7,9 +7,8 @@ import ParcellesList from '@/components/base-adresse-nationale/parcelles-list'
 
 import {sources} from './layers'
 
-function popupNumero({numero, suffixe, parcelles, lieuDitComplementNom, nomVoie, nomCommune, codeCommune, sourcePosition, sourceNomVoie}) {
+function popupNumero({numero, suffixe, parcelles, lieuDitComplementNom, nomVoie, nomCommune, codeCommune, sourcePosition}) {
   const position = sources[sourcePosition]
-  const nom = sources[sourceNomVoie]
 
   return renderToString(
     <div>
@@ -24,12 +23,7 @@ function popupNumero({numero, suffixe, parcelles, lieuDitComplementNom, nomVoie,
       <div className='infos-container'>
         <div className='separator' />
         <div className='infos'>
-          {nom ? (
-            <div>Nom : <b style={{color: nom.color}}>{nom.name}</b></div>
-          ) : (
-            <div>Nom : <i>source inconnue</i></div>
-          )}
-          <div>Position : <b style={{color: position.color}}>{position.name}</b></div>
+          <div>Source de l’adresse : <b style={{color: position.color}}>{position.name}</b></div>
         </div>
       </div>
 


### PR DESCRIPTION
Nouvelles couleurs plus lisibles pour les différentes sources
Affichage de la source de l'adresse plutôt que la source de la position et du nom.