### PR TITLE
Correction de l'affichage du logo "certifié" pour les communes sans adresse

### DIFF
--- a/components/base-adresse-nationale/commune/index.js
+++ b/components/base-adresse-nationale/commune/index.js
@@ -22,7 +22,7 @@ function Commune({nomCommune, codeCommune, region, departement, nbNumerosCertifi
         </div>
         <div style={{padding: '1em'}}>
           <Certification
-            isCertified={nbNumeros === nbNumerosCertifies}
+            isCertified={nbNumeros > 0 && nbNumeros === nbNumerosCertifies}
             certifiedMessage='Toutes les adresses sont certifiées par la commune'
             notCertifiedMessage='Certaines adresses ne sont pas certifiées par la commune'
           />


### PR DESCRIPTION
### Contexte
Actuellement si une commune n'a aucune adresse, celle-ci est indiquée comme "certifiée" car le nombre d'adresse est égale au nombre d'adresse certifiée (qui est de zéro)