### PR TITLE
Corrige le problème d'affichage du message d'erreur à la publication

### DIFF
--- a/pages/bases-locales/publication.js
+++ b/pages/bases-locales/publication.js
@@ -70,7 +70,7 @@ const PublicationPage = React.memo(({isRedirected, defaultBal, initialError, sub
       await submitBal(submissionId)
       setStep(5)
     } catch (error) {
-      setError('Impossible de publier la Base Adresse Locale :', error.message)
+      setError(`Impossible de publier la Base Adresse Locale: ${error.message}`)
     }
   }, [submissionId])
 


### PR DESCRIPTION
Correction du problème d'affichage du message d'erreur à la publication d'un base adresse locale.

Lors de la publication, le message d'erreur n'affichait pas les informations techniques.

<img width="916" alt="Capture d’écran 2021-08-24 à 14 42 01" src="https://user-images.githubusercontent.com/56537238/130618207-8a0fe25d-fcc2-49d9-a067-a3c7a5901ab7.png">
