### PR TITLE
Corrige la création de submission en double lors d'un dépôt de fichier CSV

### DIFF
--- a/components/bases-locales/publication/code-authentification.js
+++ b/components/bases-locales/publication/code-authentification.js
@@ -14,12 +14,11 @@ function CodeAuthentification({balId, email, handleValidCode, sendBackCode, canc
   const [error, setError] = useState(null)
 
   const submitCode = useCallback(async () => {
-    const response = await submitAuthentificationCode(balId, code)
-
-    if (response.error) {
-      setError(response.error)
-    } else {
+    try {
+      await submitAuthentificationCode(balId, code)
       handleValidCode()
+    } catch (error) {
+      setError(error.message)
     }
   }, [balId, code, handleValidCode])
 

--- a/components/bases-locales/publication/code-authentification.js
+++ b/components/bases-locales/publication/code-authentification.js
@@ -9,18 +9,18 @@ import theme from '@/styles/theme'
 import Button from '@/components/button'
 import Notification from '@/components/notification'
 
-function CodeAuthentification({balId, email, handleValidCode, sendBackCode, cancel}) {
+function CodeAuthentification({submissionId, email, handleValidCode, sendBackCode, cancel}) {
   const [code, setCode] = useState('')
   const [error, setError] = useState(null)
 
   const submitCode = useCallback(async () => {
     try {
-      await submitAuthentificationCode(balId, code)
+      await submitAuthentificationCode(submissionId, code)
       handleValidCode()
     } catch (error) {
       setError(error.message)
     }
-  }, [balId, code, handleValidCode])
+  }, [submissionId, code, handleValidCode])
 
   const handleInput = event => {
     const {value} = event.target
@@ -121,7 +121,7 @@ function CodeAuthentification({balId, email, handleValidCode, sendBackCode, canc
 }
 
 CodeAuthentification.propTypes = {
-  balId: PropTypes.string.isRequired,
+  submissionId: PropTypes.string.isRequired,
   email: PropTypes.string.isRequired,
   handleValidCode: PropTypes.func.isRequired,
   sendBackCode: PropTypes.func.isRequired,

--- a/components/bases-locales/publication/manage-file.js
+++ b/components/bases-locales/publication/manage-file.js
@@ -43,9 +43,8 @@ const ManageFile = React.memo(({error, handleError, handleFile}) => {
     if (file) {
       handleError(null)
       setReport(null)
-      parseFile(file)
     }
-  }, [file, parseFile, handleError])
+  }, [file, handleError])
 
   useEffect(() => {
     if (error) {
@@ -73,8 +72,9 @@ const ManageFile = React.memo(({error, handleError, handleFile}) => {
       handleError('Ce fichier est trop volumineux. Vous devez déposer un fichier de moins de 10 Mo.')
     } else {
       setFile(file)
+      parseFile(file)
     }
-  }, [setLoading, handleError])
+  }, [setLoading, handleError, parseFile])
 
   return (
     <>

--- a/lib/bal/api.js
+++ b/lib/bal/api.js
@@ -1,5 +1,3 @@
-import HttpError from '../http-error'
-
 export const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'https://backend.adresse.data.gouv.fr'
 
 async function _fetch(url, method, body) {
@@ -19,7 +17,8 @@ async function _fetch(url, method, body) {
   const contentType = response.headers.get('content-type')
 
   if (!response.ok) {
-    throw new HttpError(response)
+    const {message} = await response.json()
+    throw new Error(message)
   }
 
   if (response.ok && contentType && contentType.includes('application/json')) {

--- a/pages/bases-locales/publication.js
+++ b/pages/bases-locales/publication.js
@@ -1,3 +1,4 @@
+
 import React, {useState, useCallback, useEffect} from 'react'
 import PropTypes from 'prop-types'
 import Router from 'next/router'
@@ -20,9 +21,9 @@ import Publishing from '@/components/bases-locales/publication/publishing'
 import Published from '@/components/bases-locales/publication/published'
 import CodeAuthentification from '@/components/bases-locales/publication/code-authentification'
 
-const getStep = bal => {
-  if (bal) {
-    switch (bal.status) {
+const getStep = submission => {
+  if (submission) {
+    switch (submission.status) {
       case 'created':
         return 2
       case 'pending':
@@ -37,16 +38,16 @@ const getStep = bal => {
   }
 }
 
-const PublicationPage = React.memo(({isRedirected, defaultBal, initialError, submissionId}) => {
-  const [bal, setBal] = useState(defaultBal)
-  const [step, setStep] = useState(getStep(bal))
+const PublicationPage = React.memo(({isRedirected, defaultSubmission, initialError, submissionId}) => {
+  const [submission, setSubmission] = useState(defaultSubmission)
+  const [step, setStep] = useState(getStep(submission))
   const [authType, setAuthType] = useState()
   const [error, setError] = useState(initialError)
 
   const handleFile = async file => {
     try {
-      const bal = await uploadCSV(file)
-      setBal(bal)
+      const submission = await uploadCSV(file)
+      setSubmission(submission)
       setStep(2)
     } catch (error) {
       setError(error.message)
@@ -54,7 +55,7 @@ const PublicationPage = React.memo(({isRedirected, defaultBal, initialError, sub
   }
 
   const handleCodeAuthentification = async () => {
-    const response = await askAuthentificationCode(bal._id)
+    const response = await askAuthentificationCode(submission._id)
 
     if (response.ok) {
       setAuthType('code')
@@ -75,28 +76,28 @@ const PublicationPage = React.memo(({isRedirected, defaultBal, initialError, sub
   }, [submissionId])
 
   useEffect(() => {
-    const step = getStep(bal)
+    const step = getStep(submission)
     setStep(step)
-  }, [bal])
+  }, [submission])
 
   useEffect(() => {
     setError(null)
   }, [step])
 
   useEffect(() => {
-    if (bal) {
+    if (submission) {
       if (!submissionId) {
-        const href = `/bases-locales/publication?submissionId=${bal._id}`
+        const href = `/bases-locales/publication?submissionId=${submission._id}`
         Router.push(href, {shallow: true})
       }
 
-      if (bal.authenticationError) {
-        setError(bal.authenticationError)
+      if (submission.authenticationError) {
+        setError(submission.authenticationError)
       }
     } else if (step > 1) {
       setError('Aucune Base Adresse Locale n’a été trouvée')
     }
-  }, [step, bal, error, submissionId])
+  }, [step, submission, error, submissionId])
 
   return (
     <Page>
@@ -110,7 +111,7 @@ const PublicationPage = React.memo(({isRedirected, defaultBal, initialError, sub
 
       <Section>
         <h1>Publication d’une Base Adresse Locale</h1>
-        {bal && <h3>{bal.commune.nom} - {bal.commune.code}</h3>}
+        {submission && <h3>{submission.commune.nom} - {submission.commune.code}</h3>}
 
         <Steps step={step} />
 
@@ -127,17 +128,17 @@ const PublicationPage = React.memo(({isRedirected, defaultBal, initialError, sub
 
           {step === 2 && (
             <Authentification
-              communeEmail={bal.commune.email}
+              communeEmail={submission.commune.email}
               handleCodeAuthentification={handleCodeAuthentification}
-              authenticationUrl={bal.authenticationUrl}
+              authenticationUrl={submission.authenticationUrl}
             />
           )}
 
           {step === 3 && (
             authType === 'code' ? (
               <CodeAuthentification
-                balId={bal._id}
-                email={bal.commune.email}
+                submissionId={submission._id}
+                email={submission.commune.email}
                 handleValidCode={() => setStep(4)}
                 sendBackCode={handleCodeAuthentification}
                 cancel={() => setStep(2)}
@@ -147,14 +148,14 @@ const PublicationPage = React.memo(({isRedirected, defaultBal, initialError, sub
 
           {step === 4 && (
             <Publishing
-              user={bal.authentication}
-              commune={bal.commune}
+              user={submission.authentication}
+              commune={submission.commune}
               publication={handlePublication}
             />
           )}
 
           {step === 5 && (
-            <Published {...bal} />
+            <Published {...submission} />
           )}
         </div>
       </Section>
@@ -170,13 +171,13 @@ const PublicationPage = React.memo(({isRedirected, defaultBal, initialError, sub
 
 PublicationPage.getInitialProps = async ({query}) => {
   const {url, submissionId} = query
-  let bal
+  let submission
 
   if (submissionId) {
-    bal = await getSubmissions(submissionId)
+    submission = await getSubmissions(submissionId)
   } else if (url) {
     try {
-      bal = await submissionsBal(decodeURIComponent(url))
+      submission = await submissionsBal(decodeURIComponent(url))
     } catch {
       return {
         initialError: 'Une erreur est survenue lors de la récupération du fichier'
@@ -186,7 +187,7 @@ PublicationPage.getInitialProps = async ({query}) => {
 
   return {
     isRedirected: Boolean(url),
-    defaultBal: bal,
+    defaultSubmission: submission,
     submissionId,
     user: {}
   }
@@ -194,7 +195,7 @@ PublicationPage.getInitialProps = async ({query}) => {
 
 PublicationPage.propTypes = {
   isRedirected: PropTypes.bool,
-  defaultBal: PropTypes.shape({
+  defaultSubmission: PropTypes.shape({
     _id: PropTypes.string.isRequired,
     status: PropTypes.string.isRequired,
     commune: PropTypes.object.isRequired,
@@ -209,7 +210,7 @@ PublicationPage.propTypes = {
 
 PublicationPage.defaultProps = {
   isRedirected: false,
-  defaultBal: null,
+  defaultSubmission: null,
   submissionId: null,
   initialError: null
 }


### PR DESCRIPTION
## Contexte
Le support a remonté des erreurs lors de tentative de publication de BAL via un fichier CSV. Cette erreur "vide" bloque la publication.

![pballex](https://user-images.githubusercontent.com/7040549/131137587-f8f619e3-6baf-473b-85f1-c7781df2c6c1.jpg)

## Identification
Il s'est avéré que le dépôt d'un fichier CSV provoquait la création de plusieurs `submissions` et il pouvait arrivé qu'un mauvais `submissionId` soit envoyé lors de la demande de publication. De plus, les messages ne remonte pas correctement à l'utilisateur car mal récupérer par `HttpError`.

## Résolution
- L'upload du CSV ne se fait plus grâce à la `state` `file` mais directement après validation du fichier, évitant ainsi que la méthode soit appelée plusieurs fois.
- `HttpError` a été remplacé afin de pouvoir récupérer le message de l'api depuis le `body` de la réponse.
- La récupération du message d'erreur pour la validation du code d'authentification a été corrigé.
- La `state` `bal` a été renommée en `submission`.