### PR TITLE
Change l'URL du fond de carte photos aériennes IGN

### DIFF
--- a/components/mapbox/map.js
+++ b/components/mapbox/map.js
@@ -24,7 +24,7 @@ const STYLES = {
     sources: {
       'raster-tiles': {
         type: 'raster',
-        tiles: ['https://tiles.geo.api.gouv.fr/photographies-aeriennes/tiles/{z}/{x}/{y}'],
+        tiles: ['https://wxs.ign.fr/essentiels/geoportail/wmts?layer=ORTHOIMAGERY.ORTHOPHOTOS&style=normal&tilematrixset=PM&Service=WMTS&Request=GetTile&Version=1.0.0&Format=image%2Fjpeg&TileMatrix={z}&TileCol={x}&TileRow={y}'],
         tileSize: 256,
         attribution: '© IGN'
       }


### PR DESCRIPTION
Suppression du proxy Etalab.
Il n'est plus nécessaire.

Avantages :
- plus besoin d'espace de stockage pour le cache
- un composant en moins à maintenir

Inconvénient :
- On perd l'HTTP/2 pour le moment