### PR TITLE
Corrige le problème d'affichage du message d'erreur à la publication

### DIFF
--- a/components/bases-locales/publication/code-authentification.js
+++ b/components/bases-locales/publication/code-authentification.js
@@ -15,7 +15,12 @@ function CodeAuthentification({submissionId, email, handleValidCode, sendBackCod
 
   const submitCode = useCallback(async () => {
     try {
-      await submitAuthentificationCode(submissionId, code)
+      const response = await submitAuthentificationCode(submissionId, code)
+
+      if (response.error) {
+        throw new Error(response.error)
+      }
+
       handleValidCode()
     } catch (error) {
       setError(error.message)


### PR DESCRIPTION
Cette PR corrige un problème d'affichage du message d'erreur affiché, si le code de validation n'est pas correct, au moment de la publication d'une Base Adresse Locale.

