### PR TITLE
Correction du code couleur affiché pour les BAL

### DIFF
--- a/components/base-adresse-nationale/commune/index.js
+++ b/components/base-adresse-nationale/commune/index.js
@@ -34,7 +34,7 @@ function Commune({nomCommune, codeCommune, region, departement, voies, nbVoies, 
         </div>
         <div style={{padding: '1em'}}>
           <Certification
-            isCertified={nbNumerosCertifies > 0}
+            isCertified={typeComposition === 'bal'}
             validIconColor={certificationInProgress ? theme.border : theme.successBorder}
             certifiedMessage={
               isAllCertified ?


### PR DESCRIPTION
## Contexte
Actuellement si une commune possède au moins une adresse certifiée alors celle-ci affiche que les adresses sont en cours de certification alors que ce statut est réservé aux Bases Adresses Locales.

## Modification
Affichage de l'icône "certifié" uniquement si la commune est issue d'une BAL.