### PR TITLE
Indiquer une certification en cours au niveau de l'adresse

### DIFF
--- a/components/base-adresse-nationale/numero/index.js
+++ b/components/base-adresse-nationale/numero/index.js
@@ -1,7 +1,9 @@
 import React, {useContext, useState} from 'react'
 import PropTypes from 'prop-types'
 import Link from 'next/link'
+
 import colors from '@/styles/colors'
+import theme from '@/styles/theme'
 
 import Alert from '@/components/alert'
 import {getNumeroComplet} from '@/lib/ban'
@@ -13,7 +15,7 @@ import CoordinatesCopy from './coordinates-copy'
 
 import DeviceContext from '@/contexts/device'
 
-function Numero({numero, suffixe, lieuDitComplementNom, certifie, commune, voie, libelleAcheminement, parcelles, codePostal, cleInterop, lat, lon, isMobile}) {
+function Numero({numero, suffixe, lieuDitComplementNom, certifie, sourcePosition, commune, voie, libelleAcheminement, parcelles, codePostal, cleInterop, lat, lon, isMobile}) {
   const {isSafariBrowser} = useContext(DeviceContext)
   const [copyError, setCopyError] = useState(null)
   const [isCopyAvailable, setIsCopyAvailable] = useState(true)
@@ -31,9 +33,14 @@ function Numero({numero, suffixe, lieuDitComplementNom, certifie, commune, voie,
         </div>
         <div style={{padding: '1em'}}>
           <Certification
-            isCertified={certifie}
-            certifiedMessage='Ce numéro est certifié par la commune'
-            notCertifiedMessage='Ce numéro n’est pas certifié par la commune'
+            isCertified={certifie || sourcePosition === 'bal'}
+            validIconColor={certifie ? theme.successBorder : theme.border}
+            certifiedMessage={
+              certifie ?
+                'Cette adresse est certifiée par la commune' :
+                'Cette adresse est en cours de certification par la commune'
+            }
+            notCertifiedMessage='Cette adresse n’est pas certifiée par la commune'
           />
         </div>
       </div>
@@ -128,6 +135,7 @@ Numero.propTypes = {
   suffixe: PropTypes.string,
   lieuDitComplementNom: PropTypes.string,
   certifie: PropTypes.bool.isRequired,
+  sourcePosition: PropTypes.string.isRequired,
   parcelles: PropTypes.array.isRequired,
   commune: PropTypes.shape({
     id: PropTypes.string.isRequired,

--- a/components/base-adresse-nationale/voie/numero.js
+++ b/components/base-adresse-nationale/voie/numero.js
@@ -7,7 +7,7 @@ import theme from '@/styles/theme'
 import {getNumeroComplet} from '@/lib/ban'
 import Certification from '../certification'
 
-function Numero({id, numero, suffixe, lieuDitComplementNom, isCertified}) {
+function Numero({id, numero, suffixe, lieuDitComplementNom, sourcePosition, isCertified}) {
   return (
     <Link href={`/base-adresse-nationale?id=${id}`} as={`/base-adresse-nationale/${id}`}>
       <a>
@@ -16,8 +16,14 @@ function Numero({id, numero, suffixe, lieuDitComplementNom, isCertified}) {
         </div>
         <div className='certification'>
           <Certification
-            isCertified={isCertified}
-            certifiedMessage='Cette adresse est certifiée par la commune'
+            isCertified={isCertified || sourcePosition === 'bal'}
+            validIconColor={isCertified ? theme.successBorder : theme.border}
+            certifiedMessage={
+              isCertified ?
+                'Cette adresse est certifiée par la commune' :
+                'Cette adresse est en cours de certification par la commune'
+            }
+            notCertifiedMessage='Cette adresse n’est pas certifiée par la commune'
             iconSize={18}
             tooltipDirection='left'
           />
@@ -65,7 +71,8 @@ Numero.propTypes = {
   suffixe: PropTypes.string,
   numero: PropTypes.string.isRequired,
   lieuDitComplementNom: PropTypes.string,
-  isCertified: PropTypes.bool.isRequired
+  isCertified: PropTypes.bool.isRequired,
+  sourcePosition: PropTypes.string.isRequired
 }
 
 export default Numero

--- a/components/mapbox/ban-map/index.js
+++ b/components/mapbox/ban-map/index.js
@@ -54,6 +54,7 @@ const ZOOM_RANGE = {
 
 const certificationLegend = {
   certified: {name: 'Certifiée', color: theme.successBorder},
+  certificationInProgress: {name: 'Certification cours', color: theme.border},
   notCertified: {name: 'Non certifiée', color: theme.warningBorder}
 }
 

--- a/components/mapbox/ban-map/layers.js
+++ b/components/mapbox/ban-map/layers.js
@@ -13,8 +13,10 @@ export const sources = {
 
 export const defaultLayerPaint = [
   'case',
-  ['boolean', ['get', 'certifie'], true],
+  ['==', ['get', 'certifie'], true],
   theme.successBorder,
+  ['==', ['get', 'sourcePosition'], 'bal'],
+  theme.border,
   theme.warningBorder
 ]
 


### PR DESCRIPTION
## Context
La dernière évolution (#854) permettant de connaitre la certification à l'adresse a introduit un nouveau pictogramme GRIS indiquant lorsqu'une commune issue d'une BAL n'avait pas encore certifiée toutes ces adresses.

Il a été décidé de ne pas répercuter ce pictogramme aux adresses pour rester simple (adresse certifiée ou non). Cependant, ces adresse affiche aujourd'hui un pictogramme ORANGE, hors certaines communes ont belle et bien vérifiée ces adresses mais n'ont pas encore validée cette certification depuis l'ajout de la fonctionnalité. 

## Évolutions
Cette PR propose d'étendre ce pictogramme GRIS `Certification en cours par la commune` aux adresses. Il sera donc affiché uniquement aux adresses non certifiées issue d'une BAL.

## Visuelles
![Capture d’écran 2021-09-08 à 10 29 07](https://user-images.githubusercontent.com/7040549/132477920-01b52414-2199-4572-8d0d-f7020643d363.png)
![Capture d’écran 2021-09-08 à 10 23 35](https://user-images.githubusercontent.com/7040549/132477928-24c86a67-e0b8-4ee9-82f6-8457af26d67a.png)
![Capture d’écran 2021-09-08 à 10 23 22](https://user-images.githubusercontent.com/7040549/132477933-f3da1ea0-a566-42a8-b25b-da115b53b1a9.png)
