### PR TITLE
Corrige le problème d’affichage de la page `/bases-locales` sur mobile

### DIFF
--- a/components/bases-locales/charte/partners.js
+++ b/components/bases-locales/charte/partners.js
@@ -31,7 +31,7 @@ function Partners({partnersList}) {
       <style jsx>{`
         .partners-container {
           display: grid;
-          grid-template-columns: repeat(auto-fit, minmax(335px, 1fr));
+          grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
           justify-items: center;
           margin-top: 4em;
           gap: 6em 5em;

--- a/components/bases-locales/index.js
+++ b/components/bases-locales/index.js
@@ -167,7 +167,7 @@ const BasesLocales = React.memo(({datasets, stats}) => {
       <style jsx>{`
         .parters {
           display: grid;
-          grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+          grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
           justify-content: space-around;
           margin: 2em 0;
           align-items: center;
@@ -209,15 +209,14 @@ const BasesLocales = React.memo(({datasets, stats}) => {
 
         .map-stats-container {
           display: grid;
-          grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
-          margin: 4em 0;
+          grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+          margin: 2em 0;
         }
 
         .stats {
           display: flex;
           flex-direction: column;
           justify-content: space-around;
-          margin-right: 1em;
         }
 
         .bal-cover-map-container {


### PR DESCRIPTION
Modification des valeurs de tailles minimums pour correspondre aux écrans mobiles actuels et éviter un débordement en largeur.

Avant :

![Capture d’écran 2021-10-12 à 10 17 39](https://user-images.githubusercontent.com/56537238/136918872-5400c250-2142-4f8d-9ae8-4c151933b99d.png)

![Capture d’écran 2021-10-12 à 10 18 29](https://user-images.githubusercontent.com/56537238/136918895-9336198f-1da9-474f-80a5-0708d39981bd.png)

Après : 

![Capture d’écran 2021-10-12 à 10 18 12](https://user-images.githubusercontent.com/56537238/136918959-a8b1a11f-a65b-46b4-9e94-a8e4560fc2dc.png)

![Capture d’écran 2021-10-12 à 10 18 43](https://user-images.githubusercontent.com/56537238/136919001-b1d7bcec-ef94-4607-8e18-db73ccf34b67.png)


Fix #903 