### PR TITLE
Correction du problème d’affichage de l’iframe Infolettre

### DIFF
--- a/server.js
+++ b/server.js
@@ -24,7 +24,8 @@ app.prepare().then(() => {
           'child-src': [
             '\'self\'',
             'data:',
-            'blob:'
+            'blob:',
+            '*.sibforms.com'
           ],
           'connect-src': [
             'api-adresse.data.gouv.fr',


### PR DESCRIPTION
## Contexte : 

L’`iframe` permettant de s’inscrire à l’infolettre de se charge plus. Une erreur en console indique que la requête est bloquée.

Cette requête est bloquée par [Helmet](https://helmetjs.github.io/).

## Solution : 

Modifier la configuration d’Helmet pour accepter les requêtes en provenance du fournisseur de l’`iframe` permettant de s’inscrire à l’infolettre.


