### PR TITLE
feat: update package validateur to v3.1.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.3",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.645.0",
-        "@ban-team/validateur-bal": "^3.1.12",
+        "@ban-team/validateur-bal": "^3.1.13",
         "@codegouvfr/react-dsfr": "^1.14.1",
         "@etalab/decoupage-administratif": "^5.2.0",
         "@next/bundle-analyzer": "^14.2.13",
@@ -2769,9 +2769,9 @@
       "license": "MIT"
     },
     "node_modules/@ban-team/validateur-bal": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/@ban-team/validateur-bal/-/validateur-bal-3.1.12.tgz",
-      "integrity": "sha512-OcVKjZVjgWZ2kNX2CAfkf2+QG+togiAbF9PDhmWdUO2+a3PNj1l61Pd+fRQm8+SN7OXdE6VJ+5LnCsewWgCoow==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/@ban-team/validateur-bal/-/validateur-bal-3.1.13.tgz",
+      "integrity": "sha512-GtIaWSg+2vqtj8sPDhFikxdqWD80142SWkxgITfkJGfaSXStwRiIFR0nuAicXrj8+SYXFrzAFI/k5WJoVCk/vA==",
       "license": "MIT",
       "dependencies": {
         "@ban-team/adresses-util": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.645.0",
-    "@ban-team/validateur-bal": "^3.1.12",
+    "@ban-team/validateur-bal": "^3.1.13",
     "@codegouvfr/react-dsfr": "^1.14.1",
     "@etalab/decoupage-administratif": "^5.2.0",
     "@next/bundle-analyzer": "^14.2.13",

--- a/src/components/MiseEnForme/MiseEnFormeDocumentation.tsx
+++ b/src/components/MiseEnForme/MiseEnFormeDocumentation.tsx
@@ -3,6 +3,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import Section from '@/components/Section'
+import Alert from '@codegouvfr/react-dsfr/Alert'
 
 export const CodeWrapper = styled.code`
   background-color: #eee;
@@ -14,21 +15,35 @@ export default function MiseEnFormeDocumentation() {
   return (
     <Section title="Documentation" theme="primary">
       <h5>
-        Cet outil permet la mise en forme d&apos;un fichier BAL avec ces deux fonctionnalités :
+        Cet outil permet la mise en forme d&apos;un fichier BAL avec ces deux fonctionnalités
       </h5>
-      <h5>Peut générer des valeurs par défaut pour certains champs manquants</h5>
+      <h5>Peut générer des valeurs par défaut pour certains champs manquants : </h5>
       <ul>
-        <li><b>id_ban_commune</b> : uuid proposé par la BAN</li>
-        <li><b>id_ban_toponyme</b> : uuid généré aléatoirement (identique pour les lignes avec la même <CodeWrapper>voie_nom</CodeWrapper>)</li>
-        <li><b>id_ban_adresse</b> : uuid généré aléatoirement (identique pour les numéros avec plusieurs positions)</li>
-        <li><b>commune_insee</b> : rempli s&apos;il est présent dans la <CodeWrapper>cle_interop</CodeWrapper></li>
-        <li><b>commune_nom</b> : rempli à partir du <CodeWrapper>commune_insee</CodeWrapper> (même si calculé)</li>
-        <li><b>date_der_maj</b> : rempli avec la date du jour</li>
+        <li><CodeWrapper>id_ban_commune</CodeWrapper> <b>uuid</b> proposé par la route district de la BAN (ex : <a href="https://plateforme.adresse.data.gouv.fr/api/district/cog/12218" target="_blank">https://plateforme.adresse.data.gouv.fr/api/district/cog/12218</a>)</li>
+        <li><CodeWrapper>id_ban_toponyme</CodeWrapper> <b>uuid</b> généré aléatoirement (identique pour les lignes avec la même <CodeWrapper>voie_nom</CodeWrapper>)</li>
+        <li><CodeWrapper>id_ban_adresse</CodeWrapper> <b>uuid</b> généré aléatoirement (identique pour les numéros avec plusieurs positions)</li>
+      </ul>
+      <Alert
+        severity="info"
+        closable={false}
+        small={false}
+        title="Génération des identifiants BAN"
+        description={(
+          <>
+            <p>La mise en forme permet donc de générer les identifiants BAN.</p>
+            <p>Elle permet également de les maintenir à jour (ex: si vous rajoutez une ligne avec le même <CodeWrapper>voie_nom</CodeWrapper>, l&apos;identifiant <CodeWrapper>id_ban_toponyme</CodeWrapper> sera le même pour les deux lignes)</p>
+          </>
+        )}
+      />
+      <ul>
+        <li><CodeWrapper>commune_insee</CodeWrapper> rempli s&apos;il est présent dans la <CodeWrapper>cle_interop</CodeWrapper></li>
+        <li><CodeWrapper>commune_nom</CodeWrapper> rempli à partir du <CodeWrapper>commune_insee</CodeWrapper> (même si calculé)</li>
+        <li><CodeWrapper>date_der_maj</CodeWrapper> rempli avec la date du jour</li>
       </ul>
       <br />
       <h5>Peut améliorer certaines valeurs de champs existants qui ne sont pas optimales :</h5>
       <ul>
-        <li><b>date_der_maj</b> : transforme la date au bon format <CodeWrapper>yyyy-MM-dd</CodeWrapper> si elle est reconnue</li>
+        <li><CodeWrapper>date_der_maj</CodeWrapper> transforme la date au bon format <CodeWrapper>yyyy-MM-dd</CodeWrapper> si elle est reconnue</li>
       </ul>
     </Section>
   )


### PR DESCRIPTION
## MISE A JOUR DU VALIDATEUR

### EXPLICATION

En regardant si la mise en forme pouvait être utilisé pour le suivi d'un fichier BAL: rajouté les ids de manière intéligente si une commune rajoute des adresses, je me suis rendu compte:
- Que la mise en forme n'utilise pas tout le temp le même `id_toponyme_ban` pour une nouvelle ligne qui aurais le même `voie_nom`
- Que la mise en forme utilise tout le temp le même `id_adresse_ban` pour les ligne avec le même `numero`, `suffixe` ry `commune_deleguee_insee` indépendament du `voie_nom`

### FONCTIONNALITE

- Lorsque plusieurs lignes on le même `voie_nom` et que l'une d'entre elle a un `id_toponyme_ban`, autocomplété les `id_toponyme_ban` des autres lignes avec ce dernier

- Lorsque plusieurs lignes on le même `voie_nom` et `numero` et que l'une d'entre elle a un `id_adresse_ban`, autocomplété les `id_adresse_ban` des autres lignes avec ce dernier

### EXEMPLE

| id_ban_commune | id_ban_toponyme | id_ban_adresse | voie_nom | numero |
|--------|--------|--------|--------|--------|
| 0de14468-49fa-4dff-b8ad-a9f2ed2c0a9c | 9373af6a-8af1-4920-9b54-1245ca6ccff4 | 97dd8d70-cf29-4006-83e8-d4f9dff36558 | Boulevard des Maréchaux | 828 |
| | | | Boulevard des Maréchaux | 828 |
| | | | Boulevard des Maréchaux | 999 |
| | | | Rue du colombier | 828 |

Avec ce fichier en entré, en sortie d'autofix on doit avoir:
- 2eme ligne: `id_ban_toponyme` et `id_ban_adresse` identique a la 1ere
- 3eme ligne: `id_ban_toponyme` identiquea la  1ere et `id_ban_adresse` différents des autres lignes
- 4eme ligne: `id_ban_toponyme` et `id_ban_adresse` différents des autres lignes

## MISE A JOUR DE LA DOC

<img width="1232" height="519" alt="Capture d’écran 2025-07-15 à 15 24 11" src="https://github.com/user-attachments/assets/bab3922c-2b3a-494d-9ea6-aeb6d6abeba2" />

