### PR TITLE
[quickfix] footer qui déborde sur la page

### DIFF
--- a/src/layouts/Footer.styles.tsx
+++ b/src/layouts/Footer.styles.tsx
@@ -40,7 +40,7 @@ export const FooterWrapper = styled.footer<{ $isHidden: boolean, $isEventReady: 
       max-height: 75dvh;
       overflow: visible;
       bottom: 0;
-      transform: translateY(calc(100% - ${footerDisplayButtonHeight}));
+      transform: translateY(100%);
 
       .footer-display-button {
         display: flex;


### PR DESCRIPTION
Sur la page de l'explorateur le pieds de page déborde sur la zone affiché ce qui empêche certaines actions.

cette zone devait être interactive
mais 
- ne fonctionne pas en prod 
- est perturbante avec tous les effets tiroir sur la page
- bloque des actions du fait qu'elle ne fonctionne pas 


Ce fix rapide enlève cette zone de débordement.

link: #2231 

Vu de la zone incriminé
<img width="1006" height="792" alt="image" src="https://github.com/user-attachments/assets/64ce7d09-c570-4895-93a2-4df4686f607b" />

Test de validation : les éléments d'attributions ( liens)  doivent réagir au clic