### PR TITLE
patch: update package validateur v3.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.3",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.645.0",
-        "@ban-team/validateur-bal": "^3.3.1",
+        "@ban-team/validateur-bal": "^3.3.2",
         "@codegouvfr/react-dsfr": "^1.14.1",
         "@etalab/decoupage-administratif": "^5.2.0",
         "@next/bundle-analyzer": "^14.2.13",
@@ -88,7 +88,7 @@
       },
       "engines": {
         "node": "22",
-        "npm": ">=10"
+        "npm": "11.6.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2772,9 +2772,9 @@
       "license": "MIT"
     },
     "node_modules/@ban-team/validateur-bal": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@ban-team/validateur-bal/-/validateur-bal-3.3.1.tgz",
-      "integrity": "sha512-jQLYr9vqqqvm+TfopNx0Iy1LEC6nVq5zxFKKiulgM1xA+S5dxjmxyLDPNlSyUltRjvt+vPJQoKjOHZKUFg4tTw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@ban-team/validateur-bal/-/validateur-bal-3.3.2.tgz",
+      "integrity": "sha512-09fPZ6v2fya604V1+UysbyKFg9FIEakAV9g2sZeDYRYfXJzzPc6WhrZeUOeDksbZhEnzFjK9lMh6tVBmoi7Clg==",
       "license": "MIT",
       "dependencies": {
         "@ban-team/adresses-util": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.645.0",
-    "@ban-team/validateur-bal": "^3.3.1",
+    "@ban-team/validateur-bal": "^3.3.2",
     "@codegouvfr/react-dsfr": "^1.14.1",
     "@etalab/decoupage-administratif": "^5.2.0",
     "@next/bundle-analyzer": "^14.2.13",


### PR DESCRIPTION
## PATCH

Passage de la version du package validateur-bal v3.3.1 -> v3.3.2
Pour patché l'erreur lancé lorsque les toponymes n'ont pas de positions