### PR TITLE
Ajout texte utilisation validateur bal

### DIFF
--- a/src/components/ValidateurBAL/index.tsx
+++ b/src/components/ValidateurBAL/index.tsx
@@ -121,6 +121,13 @@ export default function ValidateurBAL() {
       </Section>
       <Section title="Documentation" theme="primary">
         <p>
+          <strong>
+            L&apos;unité de gestion des adresses est la commune, ou l&apos;arrondissement pour les villes à arrondissements.
+            <br />Le Validateur BAL est conçu pour vérifier des fichiers BAL unitaires.
+            <br />En cas de gestion pluri-communale, vous devez passer un fichier BAL par commune au Validateur BAL.
+          </strong>
+        </p>
+        <p>
           Le Validateur BAL vérifie qu&apos;un fichier soit conforme au format Base Adresse Locale.
         </p>
         <p>


### PR DESCRIPTION
Sur la page validateur, ajout d'un texte pour signaler que le validateur bal est destiné à un usage pour une seule commune
Fix: #2335 

Rendu sur la page commune:
<img width="1407" height="611" alt="Capture d’écran du 2025-12-03 09-18-00" src="https://github.com/user-attachments/assets/df2e0188-7854-44ff-a1a3-61a9f723b945" />
