### PR TITLE
Ajout message information sur page formulaire de publication

### DIFF
--- a/src/components/FormulaireDePublication/index.tsx
+++ b/src/components/FormulaireDePublication/index.tsx
@@ -210,7 +210,7 @@ export default function FormulaireDePublication({ initialHabilitation, initialRe
       <div>
         <Alert
           title="Attention"
-          description="Vous allez publier votre BAL dans la Base Adresse Nationale. Pour assurer la cohérence et la généalogie de la donnée, merci de vous assurer d&apos;être reparti de la version des données telle que publiée sur la BAN.."
+          description="Vous allez publier votre BAL dans la Base Adresse Nationale. Pour assurer la cohérence et la généalogie de la donnée, merci de vous assurer d&apos;être reparti de la version des données telle que publiée sur la BAN."
           severity="warning"
         />
       </div>


### PR DESCRIPTION
Ajout d'un message de warning sur la page Formulaire de publication pour inciter les utilisateurs à utiliser leur dernière BAL publiée sur la BAN.

<img width="1435" height="677" alt="Capture d’écran du 2025-12-03 10-34-31" src="https://github.com/user-attachments/assets/517fa89a-0513-412e-865c-27b5297e5d28" />
