### PR TITLE
ajout de la carte de suivi du déploiement des identifiants

### DIFF
--- a/src/components/DeploiementBAL/DeploiementBALDashboard.tsx
+++ b/src/components/DeploiementBAL/DeploiementBALDashboard.tsx
@@ -39,6 +39,23 @@ export default function DeploiementBALMap({ initialStats, initialFilter, departe
     setOrigin(window.location.origin)
   }, [])
 
+  // Centrer la France quand on arrive sur l’onglet Déploiement idban (panel 370px à gauche)
+  const SUIVI_BAN_PANEL_WIDTH = 370
+  useEffect(() => {
+    const map = suivi.mapRef.current?.getMap()
+    if (!map) return
+    if (selectedTab === 'suivi-ban') {
+      map.setPadding({ left: SUIVI_BAN_PANEL_WIDTH, top: 0, right: 0, bottom: 0 })
+      map.flyTo({
+        center: [2.35, 47.95],
+        zoom: 4.8,
+        duration: 800,
+      })
+    } else {
+      map.setPadding({ left: 0, top: 0, right: 0, bottom: 0 })
+    }
+  }, [selectedTab])
+
   const handleSearch = useCallback(async (input: string) => {
     const filteredEpcis = await getEpcis({ q: input, limit: 10, fields: ['centre', 'contour'] })
     const filteredDepartements = departements.filter(({ nom }) => nom.toLowerCase().includes(input.toLowerCase()))

--- a/src/components/DeploiementBAL/DeploiementBALDashboard.tsx
+++ b/src/components/DeploiementBAL/DeploiementBALDashboard.tsx
@@ -51,10 +51,11 @@ export default function DeploiementBALMap({ initialStats, initialFilter, departe
         zoom: 4.8,
         duration: 800,
       })
-    } else {
+    }
+    else {
       map.setPadding({ left: 0, top: 0, right: 0, bottom: 0 })
     }
-  }, [selectedTab])
+  }, [selectedTab, suivi.mapRef])
 
   const handleSearch = useCallback(async (input: string) => {
     const filteredEpcis = await getEpcis({ q: input, limit: 10, fields: ['centre', 'contour'] })

--- a/src/components/DeploiementBAL/DeploiementBALDashboard.tsx
+++ b/src/components/DeploiementBAL/DeploiementBALDashboard.tsx
@@ -129,7 +129,6 @@ export default function DeploiementBALMap({ initialStats, initialFilter, departe
                   latitude: 47,
                   zoom: 5,
                 }}
-                projection="mercator"
                 renderWorldCopies={false}
                 mapStyle="/map-styles/osm-vector.json"
                 onClick={suivi.handleMapClick}

--- a/src/components/DeploiementBAL/DeploiementBALDashboard.tsx
+++ b/src/components/DeploiementBAL/DeploiementBALDashboard.tsx
@@ -25,12 +25,15 @@ interface DeploiementBALMapProps {
   departements: (Departement & { centre: { type: string, coordinates: number[] } })[]
 }
 
+// Mode temporaire pour tester uniquement l'onglet Déploiement idban
+const IDBAN_ONLY_TEST_MODE = true
+
 export default function DeploiementBALMap({ initialStats, initialFilter, departements }: DeploiementBALMapProps) {
   const router = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const { stats, formatedStats, filter, setFilter, filteredCodesCommmune, geometry } = useStatsDeploiement({ initialStats, initialFilter })
-  const [selectedTab, setSelectedTab] = useState<'source' | 'bal' | 'suivi-ban'>('source')
+  const [selectedTab, setSelectedTab] = useState<'source' | 'bal' | 'suivi-ban'>(IDBAN_ONLY_TEST_MODE ? 'suivi-ban' : 'source')
   const [origin, setOrigin] = useState('')
   const suiviBanInitialEaseAppliedRef = useRef(false)
 
@@ -87,6 +90,11 @@ export default function DeploiementBALMap({ initialStats, initialFilter, departe
     setFilter(filter)
   }, [setFilter, pathname, searchParams, router])
 
+  const handleTabChange = useCallback((tabId: string) => {
+    if (IDBAN_ONLY_TEST_MODE && tabId !== 'suivi-ban') return
+    setSelectedTab(tabId as 'source' | 'bal' | 'suivi-ban')
+  }, [])
+
   return (
     <StyledDeploiementBALDashboard>
       <div className="map-stats-container" id="map-stat">
@@ -107,7 +115,7 @@ export default function DeploiementBALMap({ initialStats, initialFilter, departe
               { tabId: 'bal', label: 'Suivi Mes-Adresses' },
               { tabId: 'suivi-ban', label: 'Déploiement idban' },
             ]}
-            onTabChange={setSelectedTab as (tabId: string) => void}
+            onTabChange={handleTabChange}
           >
             <div
               ref={suivi.mapContainerRef}
@@ -131,25 +139,27 @@ export default function DeploiementBALMap({ initialStats, initialFilter, departe
                 <NavigationControl showZoom showCompass position="top-right" />
                 <FullScreenControl position="top-right" container={suivi.mapContainerRef.current} />
 
-                <Source promoteId="code" id="data" type="vector" tiles={[`${origin}/api/deploiement-stats/{z}/{x}/{y}.pbf`]}>
-                  <Layer
-                    id="bal-polygon-fill"
-                    type="fill"
-                    source="data"
-                    source-layer="communes"
-                    paint={{
-                      'fill-color': getStyle(suivi.balPaintLayer, filteredCodesCommmune),
-                      'fill-opacity': [
-                        'case',
-                        ['boolean', ['feature-state', 'hover'], false],
-                        0.8,
-                        0.6,
-                      ],
-                    }}
-                    filter={['==', '$type', 'Polygon']}
-                  />
-                </Source>
-                {selectedTab !== 'suivi-ban' && (
+                {!IDBAN_ONLY_TEST_MODE && (
+                  <Source promoteId="code" id="data" type="vector" tiles={[`${origin}/api/deploiement-stats/{z}/{x}/{y}.pbf`]}>
+                    <Layer
+                      id="bal-polygon-fill"
+                      type="fill"
+                      source="data"
+                      source-layer="communes"
+                      paint={{
+                        'fill-color': getStyle(suivi.balPaintLayer, filteredCodesCommmune),
+                        'fill-opacity': [
+                          'case',
+                          ['boolean', ['feature-state', 'hover'], false],
+                          0.8,
+                          0.6,
+                        ],
+                      }}
+                      filter={['==', '$type', 'Polygon']}
+                    />
+                  </Source>
+                )}
+                {!IDBAN_ONLY_TEST_MODE && selectedTab !== 'suivi-ban' && (
                   <DeploiementMap
                     center={geometry.center}
                     zoom={geometry.zoom}

--- a/src/components/DeploiementBAL/DeploiementBALDashboard.tsx
+++ b/src/components/DeploiementBAL/DeploiementBALDashboard.tsx
@@ -5,7 +5,7 @@ import { DeploiementBALSearchResult, useStatsDeploiement } from '@/hooks/useStat
 import { getEpcis } from '@/lib/api-geo'
 import { BANStats } from '@/types/api-ban.types'
 import { Departement } from '@/types/api-geo.types'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import Map, { Layer, NavigationControl, Source } from 'react-map-gl/maplibre'
 import TabDeploiementBAL from './TabDeploiementBAL'
 import { StyledDeploiementBALDashboard } from './DeploiementBALDashboard.styles'
@@ -32,6 +32,7 @@ export default function DeploiementBALMap({ initialStats, initialFilter, departe
   const { stats, formatedStats, filter, setFilter, filteredCodesCommmune, geometry } = useStatsDeploiement({ initialStats, initialFilter })
   const [selectedTab, setSelectedTab] = useState<'source' | 'bal' | 'suivi-ban'>('source')
   const [origin, setOrigin] = useState('')
+  const suiviBanInitialEaseAppliedRef = useRef(false)
 
   const suivi = useSuiviBan({ selectedTab })
 
@@ -39,18 +40,21 @@ export default function DeploiementBALMap({ initialStats, initialFilter, departe
     setOrigin(window.location.origin)
   }, [])
 
-  // Centrer la France quand on arrive sur l’onglet Déploiement idban (panel 370px à gauche)
+  // Panel gauche à chaque fois ; recentrage France/zoom 5 uniquement au premier passage sur l’onglet (session).
   const SUIVI_BAN_PANEL_WIDTH = 370
   useEffect(() => {
     const map = suivi.mapRef.current?.getMap()
     if (!map) return
     if (selectedTab === 'suivi-ban') {
       map.setPadding({ left: SUIVI_BAN_PANEL_WIDTH, top: 0, right: 0, bottom: 0 })
-      map.flyTo({
-        center: [2.35, 47.95],
-        zoom: 4.8,
-        duration: 800,
-      })
+      if (!suiviBanInitialEaseAppliedRef.current) {
+        map.easeTo({
+          center: [2, 47],
+          zoom: 5,
+          duration: 800,
+        })
+        suiviBanInitialEaseAppliedRef.current = true
+      }
     }
     else {
       map.setPadding({ left: 0, top: 0, right: 0, bottom: 0 })
@@ -117,6 +121,8 @@ export default function DeploiementBALMap({ initialStats, initialFilter, departe
                   latitude: 47,
                   zoom: 5,
                 }}
+                projection="mercator"
+                renderWorldCopies={false}
                 mapStyle="/map-styles/osm-vector.json"
                 onClick={suivi.handleMapClick}
                 interactiveLayerIds={selectedTab === 'suivi-ban' ? suivi.interactiveLayerIds : []}

--- a/src/components/DeploiementBAL/SuiviBanMapLayers.tsx
+++ b/src/components/DeploiementBAL/SuiviBanMapLayers.tsx
@@ -1,0 +1,116 @@
+'use client'
+
+import { Layer, Source } from 'react-map-gl/maplibre'
+import { fr } from '@codegouvfr/react-dsfr'
+import { SuiviBanContext } from './useSuiviBan'
+
+const DSFR_HEX = fr.colors.getHex({ isDark: false }).decisions
+
+const STATUS_COLORS_MAP: Record<string, string> = {
+  vert: DSFR_HEX.text.default.success.default,
+  orange: DSFR_HEX.text.default.warning.default,
+  rouge: DSFR_HEX.text.default.error.default,
+  gris: DSFR_HEX.text.default.grey.default,
+}
+
+export function SuiviBanMapLayers({ suivi }: { suivi: SuiviBanContext }) {
+  const {
+    suiviBanGeoJSON,
+    suiviBanSelectedDept,
+    suiviBanCommunesGeoJSON,
+    suiviBanActiveStatuts,
+    suiviBanProducteurFilter,
+  } = suivi
+  return (
+    <>
+      {suiviBanGeoJSON && !suiviBanSelectedDept && (
+        <Source id="suivi-ban-depts" type="geojson" data={suiviBanGeoJSON}>
+          <Layer
+            id="suivi-ban-dept-fill"
+            type="fill"
+            source="suivi-ban-depts"
+            paint={{
+              'fill-color': ['coalesce', ['get', 'dominant_color'], DSFR_HEX.background.flat.grey.default],
+              'fill-opacity': ['coalesce', ['get', 'dominant_opacity'], 0.4],
+            }}
+          />
+          <Layer
+            id="suivi-ban-dept-outline"
+            type="line"
+            source="suivi-ban-depts"
+            paint={{
+              'line-color': DSFR_HEX.background.default.grey.default,
+              'line-width': 0.8,
+            }}
+          />
+          <Layer
+            id="suivi-ban-dept-hover-outline"
+            type="line"
+            source="suivi-ban-depts"
+            filter={suivi.hoveredDept
+              ? ['==', ['get', 'code'], suivi.hoveredDept.code]
+              : ['literal', false]}
+            paint={{
+              'line-color': DSFR_HEX.text.actionHigh.blueFrance.default,
+              'line-width': 3,
+            }}
+          />
+        </Source>
+      )}
+
+      {suiviBanSelectedDept && suiviBanCommunesGeoJSON && (
+        <Source id="suivi-ban-communes" type="geojson" data={suiviBanCommunesGeoJSON}>
+          <Layer
+            id="suivi-ban-commune-fill"
+            type="fill"
+            source="suivi-ban-communes"
+            filter={['all',
+              ['in', ['get', 'statut'], ['literal', suiviBanActiveStatuts]],
+              suiviBanProducteurFilter
+                ? ['==', ['get', 'producteur'], suiviBanProducteurFilter]
+                : ['literal', true],
+            ]}
+            paint={{
+              'fill-color': [
+                'match',
+                ['get', 'statut'],
+                'vert', STATUS_COLORS_MAP.vert,
+                'orange', STATUS_COLORS_MAP.orange,
+                'rouge', STATUS_COLORS_MAP.rouge,
+                STATUS_COLORS_MAP.gris,
+              ],
+              'fill-opacity': 0.75,
+            }}
+          />
+          <Layer
+            id="suivi-ban-commune-outline"
+            type="line"
+            source="suivi-ban-communes"
+            filter={['all',
+              ['in', ['get', 'statut'], ['literal', suiviBanActiveStatuts]],
+              suiviBanProducteurFilter
+                ? ['==', ['get', 'producteur'], suiviBanProducteurFilter]
+                : ['literal', true],
+            ]}
+            paint={{
+              'line-color': DSFR_HEX.background.default.grey.default,
+              'line-width': 0.5,
+            }}
+          />
+          <Layer
+            id="suivi-ban-commune-hover-outline"
+            type="line"
+            source="suivi-ban-communes"
+            filter={suivi.hoveredCommune
+              ? ['==', ['get', 'code'], suivi.hoveredCommune.code]
+              : ['literal', false]}
+            paint={{
+              'line-color': DSFR_HEX.text.actionHigh.blueFrance.default,
+              'line-width': 3,
+            }}
+          />
+        </Source>
+      )}
+    </>
+  )
+}

--- a/src/components/DeploiementBAL/SuiviBanMapLayers.tsx
+++ b/src/components/DeploiementBAL/SuiviBanMapLayers.tsx
@@ -13,57 +13,87 @@ const STATUS_COLORS_MAP: Record<string, string> = {
   gris: DSFR_HEX.text.default.grey.default,
 }
 
+const SUIVI_BAN_API = process.env.NEXT_PUBLIC_SUIVI_BAN_API_URL || 'https://suivi-ban.mut-dev.ign.fr/api'
+
 export function SuiviBanMapLayers({ suivi }: { suivi: SuiviBanContext }) {
   const {
-    suiviBanGeoJSON,
+    suiviBanDeptStats,
     suiviBanSelectedDept,
-    suiviBanCommunesGeoJSON,
     suiviBanActiveStatuts,
     suiviBanProducteurFilter,
   } = suivi
+
+  const deptColorExpression: any[] = ['match', ['get', 'code']]
+  const deptOpacityExpression: any[] = ['match', ['get', 'code']]
+  Object.entries(suiviBanDeptStats || {}).forEach(([code, stats]) => {
+    const values = [
+      { status: 'vert', count: Number(stats?.vert || 0) },
+      { status: 'orange', count: Number(stats?.orange || 0) },
+      { status: 'rouge', count: Number(stats?.rouge || 0) },
+      { status: 'gris', count: Number(stats?.gris || 0) },
+    ].sort((a, b) => b.count - a.count)
+
+    const activeTotal = values.reduce((sum, item) => sum + item.count, 0)
+    const dominantStatus = values[0]?.status || 'gris'
+    const dominantCount = values[0]?.count || 0
+    const color = STATUS_COLORS_MAP[dominantStatus] || DSFR_HEX.background.alt.grey.default
+    const opacity = activeTotal > 0 ? 0.3 + (dominantCount / activeTotal) * 0.55 : 0.4
+
+    deptColorExpression.push(code, color)
+    deptOpacityExpression.push(code, opacity)
+  })
+  deptColorExpression.push(DSFR_HEX.background.alt.grey.default)
+  deptOpacityExpression.push(0.4)
+
   return (
     <>
-      {suiviBanGeoJSON && !suiviBanSelectedDept && (
-        <Source id="suivi-ban-depts" type="geojson" data={suiviBanGeoJSON}>
+      {!suiviBanSelectedDept && (
+        <Source
+          id="suivi-ban-depts"
+          type="vector"
+          tiles={[`${SUIVI_BAN_API}/tiles/departements/{z}/{x}/{y}.pbf`]}
+          minzoom={5}
+          maxzoom={14}
+        >
           <Layer
             id="suivi-ban-dept-fill"
             type="fill"
             source="suivi-ban-depts"
+            source-layer="departements"
+            minzoom={5}
             paint={{
-              'fill-color': ['coalesce', ['get', 'dominant_color'], DSFR_HEX.background.flat.grey.default],
-              'fill-opacity': ['coalesce', ['get', 'dominant_opacity'], 0.4],
+              'fill-color': deptColorExpression as any,
+              'fill-opacity': deptOpacityExpression as any,
             }}
           />
           <Layer
             id="suivi-ban-dept-outline"
             type="line"
             source="suivi-ban-depts"
+            source-layer="departements"
+            minzoom={5}
             paint={{
               'line-color': DSFR_HEX.background.default.grey.default,
               'line-width': 0.8,
             }}
           />
-          <Layer
-            id="suivi-ban-dept-hover-outline"
-            type="line"
-            source="suivi-ban-depts"
-            filter={suivi.hoveredDept
-              ? ['==', ['get', 'code'], suivi.hoveredDept.code]
-              : ['literal', false]}
-            paint={{
-              'line-color': DSFR_HEX.text.actionHigh.blueFrance.default,
-              'line-width': 3,
-            }}
-          />
         </Source>
       )}
 
-      {suiviBanSelectedDept && suiviBanCommunesGeoJSON && (
-        <Source id="suivi-ban-communes" type="geojson" data={suiviBanCommunesGeoJSON}>
+      {suiviBanSelectedDept && (
+        <Source
+          id="suivi-ban-communes"
+          type="vector"
+          tiles={[`${SUIVI_BAN_API}/tiles/departement/${encodeURIComponent(suiviBanSelectedDept.code)}/{z}/{x}/{y}.pbf`]}
+          minzoom={6}
+          maxzoom={14}
+        >
           <Layer
             id="suivi-ban-commune-fill"
             type="fill"
             source="suivi-ban-communes"
+            source-layer="communes"
+            minzoom={6}
             filter={['all',
               ['in', ['get', 'statut'], ['literal', suiviBanActiveStatuts]],
               suiviBanProducteurFilter
@@ -86,6 +116,8 @@ export function SuiviBanMapLayers({ suivi }: { suivi: SuiviBanContext }) {
             id="suivi-ban-commune-outline"
             type="line"
             source="suivi-ban-communes"
+            source-layer="communes"
+            minzoom={6}
             filter={['all',
               ['in', ['get', 'statut'], ['literal', suiviBanActiveStatuts]],
               suiviBanProducteurFilter
@@ -95,18 +127,6 @@ export function SuiviBanMapLayers({ suivi }: { suivi: SuiviBanContext }) {
             paint={{
               'line-color': DSFR_HEX.background.default.grey.default,
               'line-width': 0.5,
-            }}
-          />
-          <Layer
-            id="suivi-ban-commune-hover-outline"
-            type="line"
-            source="suivi-ban-communes"
-            filter={suivi.hoveredCommune
-              ? ['==', ['get', 'code'], suivi.hoveredCommune.code]
-              : ['literal', false]}
-            paint={{
-              'line-color': DSFR_HEX.text.actionHigh.blueFrance.default,
-              'line-width': 3,
             }}
           />
         </Source>

--- a/src/components/DeploiementBAL/SuiviBanOverlay.tsx
+++ b/src/components/DeploiementBAL/SuiviBanOverlay.tsx
@@ -209,13 +209,13 @@ function DeptTooltip({ dept }: { dept: NonNullable<SuiviBanContext['hoveredDept'
             <div style={{ width: `${pct(dept.vert)}%`, background: DSFR_HEX_OVERLAY.text.default.success.default }} />
             <div style={{ width: `${pct(dept.orange)}%`, background: DSFR_HEX_OVERLAY.text.default.warning.default }} />
             <div style={{ width: `${pct(dept.rouge)}%`, background: DSFR_HEX_OVERLAY.text.default.error.default }} />
-            <div style={{ width: `${pct(dept.gris)}%`, background: DSFR_HEX_OVERLAY.text.default.grey.default }} />
+            {dept.gris > 0 && <div style={{ width: `${pct(dept.gris)}%`, background: DSFR_HEX_OVERLAY.text.default.grey.default }} />}
           </div>
           <div style={{ fontSize: 12, display: 'flex', gap: 10, flexWrap: 'wrap' }}>
             <span><span style={{ color: DSFR_HEX_OVERLAY.text.default.success.default }}>●</span> {pct(dept.vert)}%</span>
             <span><span style={{ color: DSFR_HEX_OVERLAY.text.default.warning.default }}>●</span> {pct(dept.orange)}%</span>
             <span><span style={{ color: DSFR_HEX_OVERLAY.text.default.error.default }}>●</span> {pct(dept.rouge)}%</span>
-            <span><span style={{ color: DSFR_HEX_OVERLAY.text.default.grey.default }}>●</span> {pct(dept.gris)}%</span>
+            {dept.gris > 0 && <span><span style={{ color: DSFR_HEX_OVERLAY.text.default.grey.default }}>●</span> {pct(dept.gris)}%</span>}
           </div>
         </>
       )}

--- a/src/components/DeploiementBAL/SuiviBanOverlay.tsx
+++ b/src/components/DeploiementBAL/SuiviBanOverlay.tsx
@@ -1,0 +1,327 @@
+'use client'
+
+import { DeploiementBALSearchResult } from '@/hooks/useStatsDeploiement'
+import TabSuiviBAN from './TabSuiviBAN'
+import { SuiviBanContext, SuiviBanSelectedDept } from './useSuiviBan'
+import { fr } from '@codegouvfr/react-dsfr'
+
+const DSFR_HEX_OVERLAY = fr.colors.getHex({ isDark: false }).decisions
+
+const COMMUNE_STATUT_LABELS: Record<string, string> = {
+  vert: 'ID fiabilisés',
+  orange: 'ID initiés à contrôler',
+  rouge: 'ID non initiés',
+  gris: 'Sans donnée',
+}
+
+const COMMUNE_STATUT_COLORS: Record<string, string> = {
+  vert: DSFR_HEX_OVERLAY.text.default.success.default,
+  orange: DSFR_HEX_OVERLAY.text.default.warning.default,
+  rouge: DSFR_HEX_OVERLAY.text.default.error.default,
+  gris: DSFR_HEX_OVERLAY.text.default.grey.default,
+}
+
+const panelStyle: React.CSSProperties = {
+  position: 'absolute',
+  left: 0,
+  top: 0,
+  bottom: 0,
+  width: 370,
+  zIndex: 10,
+  background: 'var(--background-default-grey)',
+  boxShadow: 'var(--overlap-shadow)',
+  display: 'flex',
+  flexDirection: 'column',
+  overflow: 'hidden',
+}
+
+const panelHeaderStyle: React.CSSProperties = {
+  background: 'var(--background-action-high-blue-france)',
+  padding: '12px 16px',
+  color: 'var(--text-inverted-blue-france)',
+  flexShrink: 0,
+}
+
+const panelBackBtnStyle: React.CSSProperties = {
+  background: 'var(--background-contrast-blue-france)',
+  border: 'none',
+  color: 'var(--text-action-high-blue-france)',
+  cursor: 'pointer',
+  fontSize: 11,
+  padding: '4px 10px',
+  borderRadius: 4,
+  fontWeight: 600,
+}
+
+const panelBodyStyle: React.CSSProperties = {
+  flex: 1,
+  overflowY: 'auto',
+  scrollbarWidth: 'thin',
+  scrollbarColor: 'var(--border-default-grey) transparent',
+}
+
+interface PanelProps {
+  filter: DeploiementBALSearchResult | null
+  suivi: SuiviBanContext
+}
+
+function CommuneDetails({ commune }: { commune: any }) {
+  const statut = commune?.statut || 'gris'
+  const color = COMMUNE_STATUT_COLORS[statut] || DSFR_HEX_OVERLAY.text.default.grey.default
+  return (
+    <div style={{ padding: 16 }}>
+      <div style={{ display: 'inline-block', background: `${color}22`, color, padding: '4px 10px', borderRadius: 999, fontSize: 12, fontWeight: 700, marginBottom: 12 }}>
+        {COMMUNE_STATUT_LABELS[statut] || statut}
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10, marginBottom: 12 }}>
+        <div style={{ textAlign: 'center', background: 'var(--background-contrast-grey)', borderRadius: 8, padding: '12px 6px' }}>
+          <div style={{ fontWeight: 800, fontSize: 22, lineHeight: 1.1 }}>{(commune?.nb_numeros || 0).toLocaleString('fr-FR')}</div>
+          <div style={{ fontSize: 11, color: 'var(--text-default-grey)', marginTop: 2 }}>Numéros</div>
+        </div>
+        <div style={{ textAlign: 'center', background: 'var(--background-contrast-grey)', borderRadius: 8, padding: '12px 6px' }}>
+          <div style={{ fontWeight: 800, fontSize: 22, lineHeight: 1.1 }}>{(commune?.nb_voies || 0).toLocaleString('fr-FR')}</div>
+          <div style={{ fontSize: 11, color: 'var(--text-default-grey)', marginTop: 2 }}>Voies</div>
+        </div>
+      </div>
+
+      {(commune?.producteur || commune?.type_composition) && (
+        <div style={{ background: 'var(--background-contrast-grey)', borderRadius: 8, padding: 12, fontSize: 13 }}>
+          {commune?.producteur && (
+            <div style={{ marginBottom: commune?.type_composition ? 8 : 0 }}>
+              <div style={{ fontSize: 11, color: 'var(--text-default-grey)' }}>Mandataire</div>
+              <div style={{ fontWeight: 700 }}>{commune.producteur}</div>
+            </div>
+          )}
+          {commune?.type_composition && (
+            <div>
+              <div style={{ fontSize: 11, color: 'var(--text-default-grey)' }}>Composition</div>
+              <div style={{ fontWeight: 700 }}>{commune.type_composition}</div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function SuiviBanPanel({ filter, suivi }: PanelProps) {
+  const dept: SuiviBanSelectedDept | null = suivi.suiviBanSelectedDept
+  const commune = suivi.suiviBanSelectedCommune
+  const isCommuneLevel = Boolean(dept && commune)
+  return (
+    <div style={panelStyle}>
+      {dept && (
+        <div style={panelHeaderStyle}>
+          <>
+            {!isCommuneLevel && (
+              <button type="button" onClick={suivi.handleBack} style={panelBackBtnStyle}>
+                ← France entière
+              </button>
+            )}
+            {isCommuneLevel && (
+              <button type="button" onClick={() => suivi.setSuiviBanSelectedCommune(null)} style={panelBackBtnStyle}>
+                ← {dept.nom}
+              </button>
+            )}
+            <div style={{ marginTop: 10 }}>
+              <div style={{ fontWeight: 800, fontSize: 20, lineHeight: 1.15, letterSpacing: '-0.3px' }}>
+                {isCommuneLevel ? (commune?.nom || 'Commune') : dept.nom}
+              </div>
+              <div style={{ fontSize: 11, opacity: 0.7, marginTop: 3, fontWeight: 500 }}>
+                {isCommuneLevel && (
+                  <>Commune {commune?.code || ''} · {dept.nom} ({dept.code})</>
+                )}
+                {!isCommuneLevel && (
+                  <>
+                    Département {dept.code}
+                    {suivi.suiviBanLoadingCommunes ? ' · Chargement…' : ''}
+                  </>
+                )}
+              </div>
+            </div>
+          </>
+        </div>
+      )}
+      <div style={panelBodyStyle}>
+        {isCommuneLevel && <CommuneDetails commune={commune} />}
+        {!isCommuneLevel && (
+          <TabSuiviBAN
+            filter={filter}
+            deptFilter={dept}
+            onCommuneClick={suivi.handleCommuneClick}
+            onSearchSelect={suivi.handleSearchSelect}
+            activeStatuts={suivi.suiviBanActiveStatuts}
+            onActiveStatutsChange={suivi.setSuiviBanActiveStatuts}
+            producteurFilter={suivi.suiviBanProducteurFilter}
+            onProducteurFilterChange={suivi.setSuiviBanProducteurFilter}
+            allProducteurs={suivi.suiviBanProducteurs}
+            inPanel
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+const TERRITOIRES_OPTIONS = [
+  { value: '971', label: '971 – Guadeloupe' },
+  { value: '972', label: '972 – Martinique' },
+  { value: '973', label: '973 – Guyane' },
+  { value: '974', label: '974 – La Réunion' },
+  { value: '976', label: '976 – Mayotte' },
+  { value: '975', label: '975 – Saint-Pierre-et-Miquelon' },
+  { value: '977', label: '977 – Saint-Barthélemy' },
+  { value: '978', label: '978 – Saint-Martin' },
+  { value: '988', label: '988 – Nouvelle-Calédonie' },
+  { value: '987', label: '987 – Polynésie française' },
+  { value: '986', label: '986 – Wallis-et-Futuna' },
+]
+
+interface SuiviBanOverlayProps {
+  suivi: SuiviBanContext
+  filter: DeploiementBALSearchResult | null
+}
+
+function DeptTooltip({ dept }: { dept: NonNullable<SuiviBanContext['hoveredDept']> }) {
+  const total = dept.total
+  const pct = (n: number) => total > 0 ? Math.round(n / total * 100) : 0
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: dept.x + 15,
+        top: dept.y + 15,
+        pointerEvents: 'none',
+        background: 'var(--background-default-grey)',
+        borderRadius: 8,
+        boxShadow: 'var(--overlap-shadow)',
+        padding: '10px 14px',
+        fontSize: 13,
+        zIndex: 20,
+        minWidth: 200,
+      }}
+    >
+      <div style={{ fontWeight: 700, marginBottom: 8, fontSize: 14 }}>{dept.nom}</div>
+      {total > 0 && (
+        <>
+          <div style={{ display: 'flex', height: 10, borderRadius: 5, overflow: 'hidden', border: `1px solid ${DSFR_HEX_OVERLAY.border.default.grey.default}`, marginBottom: 8 }}>
+            <div style={{ width: `${pct(dept.vert)}%`, background: DSFR_HEX_OVERLAY.text.default.success.default }} />
+            <div style={{ width: `${pct(dept.orange)}%`, background: DSFR_HEX_OVERLAY.text.default.warning.default }} />
+            <div style={{ width: `${pct(dept.rouge)}%`, background: DSFR_HEX_OVERLAY.text.default.error.default }} />
+            <div style={{ width: `${pct(dept.gris)}%`, background: DSFR_HEX_OVERLAY.text.default.grey.default }} />
+          </div>
+          <div style={{ fontSize: 12, display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+            <span><span style={{ color: DSFR_HEX_OVERLAY.text.default.success.default }}>●</span> {pct(dept.vert)}%</span>
+            <span><span style={{ color: DSFR_HEX_OVERLAY.text.default.warning.default }}>●</span> {pct(dept.orange)}%</span>
+            <span><span style={{ color: DSFR_HEX_OVERLAY.text.default.error.default }}>●</span> {pct(dept.rouge)}%</span>
+            <span><span style={{ color: DSFR_HEX_OVERLAY.text.default.grey.default }}>●</span> {pct(dept.gris)}%</span>
+          </div>
+        </>
+      )}
+      {total === 0 && (
+        <div style={{ fontSize: 12, color: DSFR_HEX_OVERLAY.text.mention.grey.default, fontStyle: 'italic' }}>Aucune donnée</div>
+      )}
+    </div>
+  )
+}
+
+function CommuneTooltip({ commune, deptNom }: { commune: NonNullable<SuiviBanContext['hoveredCommune']>, deptNom?: string }) {
+  const statut = commune.statut || 'gris'
+  const color = COMMUNE_STATUT_COLORS[statut] || DSFR_HEX_OVERLAY.text.default.grey.default
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: commune.x + 15,
+        top: commune.y + 15,
+        pointerEvents: 'none',
+        background: 'var(--background-default-grey)',
+        borderRadius: 8,
+        boxShadow: 'var(--overlap-shadow)',
+        padding: '10px 14px',
+        fontSize: 13,
+        zIndex: 20,
+        minWidth: 200,
+      }}
+    >
+      <div style={{ fontWeight: 700, marginBottom: 4, fontSize: 14 }}>{commune.nom}</div>
+      <div style={{ fontSize: 11, color: DSFR_HEX_OVERLAY.text.mention.grey.default, marginBottom: 8 }}>
+        {commune.code}{deptNom ? ` · ${deptNom}` : ''}
+      </div>
+      <div style={{ display: 'inline-block', background: `${color}22`, color, padding: '2px 8px', borderRadius: 10, fontSize: 11, fontWeight: 600, marginBottom: 8 }}>
+        {COMMUNE_STATUT_LABELS[statut] || statut}
+      </div>
+      <div style={{ display: 'flex', gap: 12, fontSize: 12 }}>
+        <span><strong>{(commune.nb_numeros || 0).toLocaleString('fr-FR')}</strong> numéros</span>
+        <span><strong>{(commune.nb_voies || 0).toLocaleString('fr-FR')}</strong> voies</span>
+      </div>
+      {commune.producteur && (
+        <div style={{ fontSize: 11, color: DSFR_HEX_OVERLAY.text.mention.grey.default, marginTop: 6 }}>Mandataire : {commune.producteur}</div>
+      )}
+    </div>
+  )
+}
+
+export function SuiviBanOverlay({ suivi, filter }: SuiviBanOverlayProps) {
+  return (
+    <div style={{ position: 'absolute', inset: 0, pointerEvents: 'none', zIndex: 10 }}>
+
+      <div style={{ pointerEvents: 'auto' }}>
+        <SuiviBanPanel suivi={suivi} filter={filter} />
+      </div>
+
+      {suivi.hoveredDept && !suivi.suiviBanSelectedDept && (
+        <DeptTooltip dept={suivi.hoveredDept} />
+      )}
+
+      {suivi.hoveredCommune && suivi.suiviBanSelectedDept && (
+        <CommuneTooltip commune={suivi.hoveredCommune} deptNom={suivi.suiviBanSelectedDept.nom} />
+      )}
+
+      <div
+        style={{
+          position: 'absolute',
+          top: 10,
+          right: 50,
+          pointerEvents: 'auto',
+          background: 'var(--background-default-grey)',
+          borderRadius: 8,
+          boxShadow: 'var(--overlap-shadow)',
+          overflow: 'hidden',
+        }}
+      >
+        <select
+          style={{
+            border: 'none',
+            padding: '9px 36px 9px 14px',
+            fontSize: 13,
+            fontWeight: 600,
+            color: 'var(--text-default-grey)',
+            background: 'var(--background-default-grey)',
+            cursor: 'pointer',
+            appearance: 'none',
+            backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='${encodeURIComponent(DSFR_HEX_OVERLAY.text.default.grey.default)}' d='M6 9L1 4h10z'/%3E%3C/svg%3E")`,
+            backgroundRepeat: 'no-repeat',
+            backgroundPosition: 'right 10px center',
+            outline: 'none',
+            minWidth: 180,
+          }}
+          value=""
+          onChange={(e) => {
+            if (e.target.value) suivi.handleTerritorySelect(e.target.value)
+            e.target.value = ''
+          }}
+        >
+          <option value="">Naviguer vers…</option>
+          <optgroup label="DOM-TOM">
+            {TERRITOIRES_OPTIONS.map(t => (
+              <option key={t.value} value={t.value}>{t.label}</option>
+            ))}
+          </optgroup>
+        </select>
+      </div>
+
+    </div>
+  )
+}

--- a/src/components/DeploiementBAL/SuiviBanOverlay.tsx
+++ b/src/components/DeploiementBAL/SuiviBanOverlay.tsx
@@ -120,7 +120,7 @@ function SuiviBanPanel({ filter, suivi }: PanelProps) {
               </button>
             )}
             {isCommuneLevel && (
-              <button type="button" onClick={() => suivi.setSuiviBanSelectedCommune(null)} style={panelBackBtnStyle}>
+              <button type="button" onClick={suivi.handleBackToDepartment} style={panelBackBtnStyle}>
                 ← {dept.nom}
               </button>
             )}
@@ -149,6 +149,10 @@ function SuiviBanPanel({ filter, suivi }: PanelProps) {
           <TabSuiviBAN
             filter={filter}
             deptFilter={dept}
+            deptCommunesMeta={suivi.suiviBanCommunesMeta}
+            deptCommunesLoading={suivi.suiviBanLoadingCommunes}
+            deptCommunesError={suivi.suiviBanCommunesError}
+            communeTilesEmpty={suivi.suiviBanCommuneTilesEmpty}
             onCommuneClick={suivi.handleCommuneClick}
             onSearchSelect={suivi.handleSearchSelect}
             activeStatuts={suivi.suiviBanActiveStatuts}

--- a/src/components/DeploiementBAL/TabSuiviBAN.tsx
+++ b/src/components/DeploiementBAL/TabSuiviBAN.tsx
@@ -739,6 +739,7 @@ export default function TabSuiviBAN({ filter, deptFilter, onCommuneClick, onSear
   })()
 
   const total = displayStats.total || 1
+  const statusesToShow = statuses.filter(s => s !== 'gris' || (displayStats?.gris ?? 0) > 0)
 
   const fmt = (n: number) => (n || 0).toLocaleString('fr-FR')
   const STAT_CARDS = activeDeptCode
@@ -848,7 +849,7 @@ export default function TabSuiviBAN({ filter, deptFilter, onCommuneClick, onSear
 
       <div className="status-section">
         <div className="status-bar">
-          {statuses.map(s => (
+          {statusesToShow.map(s => (
             <div
               key={s}
               className="status-bar-segment"
@@ -857,7 +858,7 @@ export default function TabSuiviBAN({ filter, deptFilter, onCommuneClick, onSear
           ))}
         </div>
         <div className="status-rows">
-          {statuses.map((s) => {
+          {statusesToShow.map((s) => {
             const isActive = activeStatuts.includes(s)
             const isFiltering = activeStatuts.length < 4
             const p = pct(displayStats[s] ?? 0, total)

--- a/src/components/DeploiementBAL/TabSuiviBAN.tsx
+++ b/src/components/DeploiementBAL/TabSuiviBAN.tsx
@@ -1,0 +1,1078 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import styled from 'styled-components'
+import { fr } from '@codegouvfr/react-dsfr'
+import { DeploiementBALSearchResult } from '@/hooks/useStatsDeploiement'
+const SUIVI_BAN_API = process.env.NEXT_PUBLIC_SUIVI_BAN_API_URL || 'https://suivi-ban.mut-dev.ign.fr/api'
+
+const DSFR = fr.colors.decisions
+const DSFR_HEX = fr.colors.getHex({ isDark: false }).decisions
+const GREY_ICON_STROKE_URL = encodeURIComponent(DSFR_HEX.text.mention.grey.default)
+const GREY_ICON_FILL_URL = encodeURIComponent(DSFR_HEX.text.default.grey.default)
+
+const STATUS_COLORS: Record<string, string> = {
+  vert: DSFR_HEX.text.default.success.default,
+  orange: DSFR_HEX.text.default.warning.default,
+  rouge: DSFR_HEX.text.default.error.default,
+  gris: DSFR_HEX.text.default.grey.default,
+}
+
+const STATUS_TEXT_COLORS: Record<string, string> = {
+  vert: DSFR_HEX.text.default.success.default,
+  orange: DSFR_HEX.text.default.warning.default,
+  rouge: DSFR_HEX.text.default.error.default,
+  gris: DSFR_HEX.text.default.grey.default,
+}
+
+const STATUS_BG: Record<string, string> = {
+  vert: DSFR_HEX.background.alt.greenBourgeon.default,
+  orange: DSFR_HEX.background.alt.orangeTerreBattue.default,
+  rouge: DSFR_HEX.background.alt.redMarianne.default,
+  gris: DSFR_HEX.background.alt.grey.default,
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  vert: 'ID fiabilisés',
+  orange: 'ID initiés à contrôler',
+  rouge: 'ID non initiés',
+  gris: 'Sans donnée',
+}
+
+const STATUS_LABELS_SHORT: Record<string, string> = {
+  vert: 'Fiabilisés',
+  orange: 'À contrôler',
+  rouge: 'Non initiés',
+  gris: 'Sans donnée',
+}
+
+const STATUS_ORDER = ['rouge', 'orange', 'vert', 'gris']
+
+interface SuiviBanStats {
+  total: number
+  vert: number
+  orange: number
+  rouge: number
+  gris: number
+  numeros: number
+  voies: number
+}
+
+interface Producteur {
+  nom: string
+  nb_communes: number
+  nb_depts: number
+  vert: number
+  orange: number
+  rouge: number
+}
+
+interface TabSuiviBanProps {
+  filter: DeploiementBALSearchResult | null
+  deptFilter: { code: string, nom: string } | null
+  onCommuneClick: (commune: any) => void
+  onSearchSelect?: (commune: any) => void
+  activeStatuts?: string[]
+  onActiveStatutsChange?: (statuts: string[]) => void
+  producteurFilter?: string | null
+  onProducteurFilterChange?: (p: string | null) => void
+  allProducteurs?: Producteur[]
+  inPanel?: boolean
+}
+
+const StyledWrapper = styled.div<{ $inPanel?: boolean }>`
+  margin-bottom: ${({ $inPanel }) => $inPanel ? '0' : '2rem'};
+  padding: ${({ $inPanel }) => $inPanel ? '14px' : '0'};
+
+  .global-search-wrapper {
+    position: relative;
+    margin-bottom: 0.75rem;
+  }
+
+  .status-legend-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.2);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 30;
+  }
+
+  .status-legend-dialog {
+    background: var(--background-default-grey);
+    border-radius: 10px;
+    padding: 16px 18px;
+    max-width: 420px;
+    box-shadow: var(--overlap-shadow);
+    font-size: 0.85rem;
+  }
+
+  .status-legend-title {
+    font-weight: 700;
+    margin-bottom: 10px;
+    font-size: 0.9rem;
+  }
+
+  .status-legend-content {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .status-legend-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .status-legend-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    margin-top: 4px;
+  }
+
+  .global-search-input {
+    width: 100%;
+    padding: 9px 12px 9px 36px;
+    border: 2px solid var(--border-default-grey);
+    border-radius: 8px;
+    font-size: 0.85rem;
+    background: var(--background-default-grey) url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='${GREY_ICON_STROKE_URL}' stroke-width='2'%3E%3Ccircle cx='11' cy='11' r='8'/%3E%3Cpath d='m21 21-4.35-4.35'/%3E%3C/svg%3E") no-repeat 10px center;
+    transition: border-color 0.15s;
+    box-sizing: border-box;
+
+    &:focus {
+      outline: none;
+      border-color: var(--border-active-blue-france);
+      box-shadow: 0 0 0 2px var(--background-contrast-blue-france);
+    }
+  }
+
+  .global-search-results {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    right: 0;
+    background: var(--background-default-grey);
+    border: 1px solid var(--border-default-grey);
+    border-radius: 8px;
+    box-shadow: var(--overlap-shadow);
+    z-index: 200;
+    max-height: 260px;
+    overflow-y: auto;
+  }
+
+  .search-result-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 9px 12px;
+    width: 100%;
+    background: none;
+    border: none;
+    border-bottom: 1px solid var(--border-default-grey);
+    cursor: pointer;
+    text-align: left;
+    transition: background 0.1s;
+
+    &:last-child { border-bottom: none; }
+    &:hover { background: var(--background-contrast-grey-hover); }
+  }
+
+  .search-result-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .search-result-info {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    min-width: 0;
+  }
+
+  .search-result-nom {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--text-title-grey);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .search-result-meta {
+    font-size: 0.72rem;
+    color: var(--text-mention-grey);
+  }
+
+  .search-result-loading,
+  .search-result-empty {
+    padding: 10px 14px;
+    font-size: 0.82rem;
+    color: var(--text-mention-grey);
+    text-align: center;
+  }
+
+  .stat-cards {
+    display: grid;
+    gap: ${({ $inPanel }) => $inPanel ? '0.5rem' : '1rem'};
+    margin-bottom: ${({ $inPanel }) => $inPanel ? '0.75rem' : '1.5rem'};
+
+    &.cards-4 { grid-template-columns: ${({ $inPanel }) => $inPanel ? '1fr 1fr' : 'repeat(4, 1fr)'}; }
+    &.cards-3 { grid-template-columns: ${({ $inPanel }) => $inPanel ? 'repeat(3, 1fr)' : 'repeat(3, 1fr)'}; }
+  }
+
+  .stat-card {
+    background: var(--background-default-grey);
+    border: 1px solid var(--border-default-grey);
+    border-radius: 8px;
+    border-top-width: 3px;
+    padding: ${({ $inPanel }) => $inPanel ? '0.7rem 0.75rem' : '1.25rem 1rem'};
+    text-align: left;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+  }
+
+  .stat-card-value {
+    font-size: ${({ $inPanel }) => $inPanel ? '1.25rem' : '1.75rem'};
+    font-weight: 700;
+    display: block;
+    line-height: 1.2;
+    white-space: nowrap;
+  }
+
+  .stat-card-label {
+    font-size: 0.68rem;
+    color: var(--text-default-grey);
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    margin-top: 0.25rem;
+    line-height: 1.3;
+  }
+
+  .section-title {
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: var(--text-default-grey);
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    margin-bottom: 0.5rem;
+  }
+
+  .status-section {
+    margin-bottom: ${({ $inPanel }) => $inPanel ? '0.75rem' : '1.5rem'};
+  }
+
+  .status-bar {
+    display: flex;
+    height: 6px;
+    border-radius: 4px;
+    overflow: hidden;
+    margin-bottom: 8px;
+    background: var(--background-contrast-grey);
+  }
+
+  .status-bar-segment {
+    transition: width 0.3s ease;
+  }
+
+  .status-rows {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .status-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 5px 8px;
+    border-radius: 6px;
+    border: none;
+    background: transparent;
+    text-align: left;
+    width: 100%;
+    cursor: default;
+    transition: opacity 0.15s, background 0.15s;
+
+    &.clickable {
+      cursor: pointer;
+      &:hover { background: var(--background-contrast-grey-hover); }
+      &.inactive { opacity: 0.3; }
+    }
+
+    .row-dot {
+      width: 9px;
+      height: 9px;
+      border-radius: 50%;
+      flex-shrink: 0;
+    }
+
+    .row-label {
+      flex: 1;
+      font-size: 0.8rem;
+      color: var(--text-default-grey);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .row-count {
+      font-size: 0.82rem;
+      font-weight: 700;
+      color: var(--text-title-grey);
+      white-space: nowrap;
+      min-width: 42px;
+      text-align: right;
+    }
+
+    .row-pct {
+      font-size: 0.75rem;
+      color: var(--text-mention-grey);
+      white-space: nowrap;
+      min-width: 38px;
+      text-align: right;
+    }
+
+    .row-check {
+      font-size: 0.65rem;
+      color: var(--text-action-high-blue-france);
+      flex-shrink: 0;
+      opacity: 0;
+      width: 10px;
+      &.on { opacity: 1; }
+    }
+  }
+
+  .status-group-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 4px 10px 4px 8px;
+    border-left: 3px solid transparent;
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    position: sticky;
+    top: 0;
+    z-index: 1;
+
+    .group-count-badge {
+      font-size: 0.65rem;
+      font-weight: 700;
+      padding: 1px 6px;
+      border-radius: 8px;
+      opacity: 0.85;
+    }
+  }
+
+  .commune-list-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.5rem;
+  }
+
+  .filters-row {
+    display: flex;
+    gap: 6px;
+    margin-bottom: 0.6rem;
+
+    .commune-search {
+      flex: 1;
+      min-width: 0;
+      padding: 7px 10px 7px 30px;
+      border: 1.5px solid var(--border-default-grey);
+      border-radius: 8px;
+      font-size: 0.82rem;
+      color: var(--text-default-grey);
+      background: var(--background-default-grey) url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='13' height='13' viewBox='0 0 24 24' fill='none' stroke='${GREY_ICON_STROKE_URL}' stroke-width='2'%3E%3Ccircle cx='11' cy='11' r='8'/%3E%3Cpath d='m21 21-4.35-4.35'/%3E%3C/svg%3E") no-repeat 9px center;
+
+      &::placeholder {
+        color: var(--text-mention-grey);
+      }
+
+      &:focus { outline: none; border-color: var(--border-active-blue-france); box-shadow: 0 0 0 2px var(--background-contrast-blue-france); }
+    }
+
+    .producteur-select {
+      flex: 0 0 auto;
+      max-width: 145px;
+      min-width: 100px;
+      padding: 6px 28px 6px 8px;
+      border: 1.5px solid var(--border-default-grey);
+      border-radius: 8px;
+      font-size: 0.75rem;
+      background-color: var(--background-default-grey);
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='${GREY_ICON_FILL_URL}' d='M6 9 1 4h10z'/%3E%3C/svg%3E");
+      background-repeat: no-repeat;
+      background-position: right 8px center;
+      background-size: 12px 12px;
+      color: var(--text-default-grey);
+      cursor: pointer;
+      text-overflow: ellipsis;
+      appearance: none;
+      -webkit-appearance: none;
+      -moz-appearance: none;
+
+      &:focus { outline: none; border-color: var(--border-active-blue-france); }
+      &.active { border-color: var(--border-active-blue-france); background-color: var(--background-alt-blue-france); color: var(--text-action-high-blue-france); font-weight: 600; }
+    }
+  }
+
+  .producteur-select {
+    padding: 7px 30px 7px 10px;
+    border: 1.5px solid var(--border-default-grey);
+    border-radius: 8px;
+    font-size: 0.82rem;
+    background-color: var(--background-default-grey);
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='${GREY_ICON_FILL_URL}' d='M6 9 1 4h10z'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 10px center;
+    background-size: 12px 12px;
+    color: var(--text-default-grey);
+    cursor: pointer;
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+
+    &:focus { outline: none; border-color: var(--border-active-blue-france); }
+    &.active { border-color: var(--border-active-blue-france); background-color: var(--background-alt-blue-france); color: var(--text-action-high-blue-france); font-weight: 600; }
+  }
+
+  .commune-search {
+    width: 100%;
+    padding: 7px 10px 7px 32px;
+    border: 1.5px solid var(--border-default-grey);
+    border-radius: 8px;
+    font-size: 0.85rem;
+    margin-bottom: 0.6rem;
+    background: var(--background-default-grey) url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='${GREY_ICON_STROKE_URL}' stroke-width='2'%3E%3Ccircle cx='11' cy='11' r='8'/%3E%3Cpath d='m21 21-4.35-4.35'/%3E%3C/svg%3E") no-repeat 10px center;
+    box-sizing: border-box;
+    color: var(--text-default-grey);
+
+    &::placeholder {
+      color: var(--text-mention-grey);
+    }
+
+    &:focus {
+      outline: none;
+      border-color: var(--border-active-blue-france);
+      box-shadow: 0 0 0 2px var(--background-contrast-blue-france);
+    }
+  }
+
+  .commune-list {
+    border: 1px solid var(--border-default-grey);
+    border-radius: 8px;
+    overflow: hidden;
+  }
+
+  .commune-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    cursor: pointer;
+    border-bottom: 1px solid var(--border-default-grey);
+    border-left: 4px solid transparent;
+    transition: background 0.1s;
+
+    &:last-child { border-bottom: none; }
+    &:hover { background: var(--background-alt-blue-france-hover); }
+
+    .commune-main {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .commune-name {
+      display: block;
+      font-size: 0.82rem;
+      font-weight: 600;
+      color: var(--text-title-grey);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .commune-producteur {
+      display: block;
+      font-size: 0.65rem;
+      color: var(--text-mention-grey);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      margin-top: 1px;
+    }
+
+    .commune-code {
+      font-size: 0.7rem;
+      color: var(--text-mention-grey);
+      flex-shrink: 0;
+    }
+
+    .commune-numeros {
+      font-size: 0.7rem;
+      color: var(--text-default-grey);
+      white-space: nowrap;
+      flex-shrink: 0;
+      background: var(--background-contrast-grey);
+      padding: 1px 5px;
+      border-radius: 4px;
+    }
+  }
+
+  .source-link {
+    margin-top: 1.5rem;
+    font-size: 0.8rem;
+    color: var(--text-default-grey);
+
+    a { color: var(--text-action-high-blue-france); }
+  }
+
+  .loading, .error {
+    padding: 2rem 0;
+    color: var(--text-default-grey);
+    font-size: 0.9rem;
+  }
+`
+
+function pct(value: number, total: number): number {
+  if (!total) return 0
+  return Math.round((value / total) * 1000) / 10
+}
+
+export default function TabSuiviBAN({ filter, deptFilter, onCommuneClick, onSearchSelect, activeStatuts: activeStatutsProp, onActiveStatutsChange, producteurFilter: producteurFilterProp, onProducteurFilterChange, allProducteurs = [], inPanel }: TabSuiviBanProps) {
+  const [stats, setStats] = useState<SuiviBanStats | null>(null)
+  const [communes, setCommunes] = useState<any[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(false)
+  const [activeStatutsLocal, setActiveStatutsLocal] = useState<string[]>(['rouge', 'orange', 'vert', 'gris'])
+  const [communeSearch, setCommuneSearch] = useState('')
+  const [producteurFilterLocal, setProducteurFilterLocal] = useState<string | null>(null)
+  const [globalSearch, setGlobalSearch] = useState('')
+  const [globalSearchResults, setGlobalSearchResults] = useState<any[]>([])
+  const [showStatusLegend, setShowStatusLegend] = useState(false)
+  const [globalSearchLoading, setGlobalSearchLoading] = useState(false)
+  const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const producteurFilter = producteurFilterProp !== undefined ? producteurFilterProp : producteurFilterLocal
+  const setProducteurFilter = (p: string | null) => {
+    if (onProducteurFilterChange) onProducteurFilterChange(p)
+    else setProducteurFilterLocal(p)
+  }
+
+  const activeStatuts = activeStatutsProp ?? activeStatutsLocal
+  const onChangeRef = useRef(onActiveStatutsChange)
+  onChangeRef.current = onActiveStatutsChange
+
+  const setActiveStatuts = (next: string[] | ((prev: string[]) => string[])) => {
+    const resolved = typeof next === 'function' ? next(activeStatuts) : next
+    if (onChangeRef.current) onChangeRef.current(resolved)
+    else setActiveStatutsLocal(resolved)
+  }
+
+  const activeDeptCode = deptFilter?.code ?? (filter?.type === 'Département' ? filter.code : null)
+
+  useEffect(() => {
+    setCommuneSearch('')
+    setActiveStatutsLocal(['rouge', 'orange', 'vert', 'gris'])
+    if (onChangeRef.current) onChangeRef.current(['rouge', 'orange', 'vert', 'gris'])
+
+    if (!activeDeptCode) {
+      setCommunes([])
+      return
+    }
+
+    const controller = new AbortController()
+    setLoading(true)
+    setError(false)
+
+    fetch(`${SUIVI_BAN_API}/departement/${activeDeptCode}/communes`, { signal: controller.signal })
+      .then((r) => {
+        if (!r.ok) throw new Error('API error')
+        return r.json()
+      })
+      .then((data) => {
+        if (controller.signal.aborted) return
+        const features: any[] = data?.features || []
+        const counts: SuiviBanStats = { total: features.length, vert: 0, orange: 0, rouge: 0, gris: 0, numeros: 0, voies: 0 }
+        features.forEach((f: any) => {
+          const s = (f.properties?.statut || 'gris') as keyof SuiviBanStats
+          if (s in counts) (counts[s] as number)++
+          counts.numeros += f.properties?.nb_numeros || 0
+          counts.voies += f.properties?.nb_voies || 0
+        })
+        setStats(counts)
+        setCommunes(features.map(f => f.properties).sort((a, b) =>
+          STATUS_ORDER.indexOf(a.statut || 'gris') - STATUS_ORDER.indexOf(b.statut || 'gris')
+        ))
+      })
+      .catch((e: Error) => {
+        if (e.name !== 'AbortError') setError(true)
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false)
+      })
+
+    return () => controller.abort()
+  }, [activeDeptCode])
+
+  useEffect(() => {
+    if (activeDeptCode) return
+
+    const controller = new AbortController()
+    setLoading(true)
+    setError(false)
+
+    const url = producteurFilter
+      ? `${SUIVI_BAN_API}/producteur/${encodeURIComponent(producteurFilter)}/stats`
+      : `${SUIVI_BAN_API}/stats/global`
+
+    fetch(url, { signal: controller.signal })
+      .then((r) => {
+        if (!r.ok) throw new Error('API error')
+        return r.json()
+      })
+      .then((data) => {
+        if (!controller.signal.aborted) setStats(data)
+      })
+      .catch((e: Error) => {
+        if (e.name !== 'AbortError') setError(true)
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false)
+      })
+
+    return () => controller.abort()
+  }, [activeDeptCode, producteurFilter])
+
+  useEffect(() => {
+    if (activeDeptCode) {
+      setGlobalSearchResults([])
+      return
+    }
+    if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current)
+    if (!globalSearch || globalSearch.length < 2) {
+      setGlobalSearchResults([])
+      return
+    }
+
+    searchDebounceRef.current = setTimeout(() => {
+      setGlobalSearchLoading(true)
+      fetch(`${SUIVI_BAN_API}/search?q=${encodeURIComponent(globalSearch)}`)
+        .then(r => r.json())
+        .then(data => setGlobalSearchResults(Array.isArray(data) ? data : []))
+        .catch(() => setGlobalSearchResults([]))
+        .finally(() => setGlobalSearchLoading(false))
+    }, 300)
+
+    return () => {
+      if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current)
+    }
+  }, [globalSearch, activeDeptCode])
+
+  const toggleStatut = (s: string) => {
+    setActiveStatuts(prev =>
+      prev.includes(s) ? (prev.length > 1 ? prev.filter(x => x !== s) : prev) : [...prev, s]
+    )
+  }
+
+  if (loading) return <StyledWrapper $inPanel={inPanel}><p className="loading">Chargement…</p></StyledWrapper>
+  if (error || !stats) return <StyledWrapper $inPanel={inPanel}><p className="error">Erreur de chargement.</p></StyledWrapper>
+
+  const statuses = ['vert', 'orange', 'rouge', 'gris'] as const
+
+  const uniqueProducteurs = [...new Set(communes.filter(c => c.producteur).map(c => c.producteur as string))].sort()
+
+  const filteredCommunes = communes.filter((c) => {
+    const statut = c.statut || 'gris'
+    if (!activeStatuts.includes(statut)) return false
+    if (producteurFilter && c.producteur !== producteurFilter) return false
+    if (communeSearch) {
+      const query = communeSearch.trim().toLowerCase()
+      const nom = (c.nom || '').toLowerCase()
+      const codeInsee = String(c.code || '').toLowerCase()
+      if (!nom.includes(query) && !codeInsee.includes(query)) return false
+    }
+    return true
+  })
+
+  const displayStats = (() => {
+    if (activeDeptCode && producteurFilter) {
+      const base = communes.filter(c => c.producteur === producteurFilter)
+      return {
+        total: base.length,
+        vert: base.filter(c => c.statut === 'vert').length,
+        orange: base.filter(c => c.statut === 'orange').length,
+        rouge: base.filter(c => c.statut === 'rouge').length,
+        gris: base.filter(c => (c.statut || 'gris') === 'gris').length,
+        numeros: base.reduce((sum, c) => sum + (c.nb_numeros || 0), 0),
+        voies: base.reduce((sum, c) => sum + (c.nb_voies || 0), 0),
+      }
+    }
+    if (!activeDeptCode && producteurFilter) {
+      const entry = allProducteurs.find(p => p.nom === producteurFilter)
+      if (entry) {
+        const v = entry.vert || 0
+        const o = entry.orange || 0
+        const r = entry.rouge || 0
+        const t = entry.nb_communes || 0
+        return {
+          total: t,
+          vert: v,
+          orange: o,
+          rouge: r,
+          gris: Math.max(0, t - v - o - r),
+          numeros: stats?.numeros || 0,
+          voies: stats?.voies || 0,
+        }
+      }
+    }
+    return stats
+  })()
+
+  const total = displayStats.total || 1
+
+  const fmt = (n: number) => (n || 0).toLocaleString('fr-FR')
+  const STAT_CARDS = activeDeptCode
+    ? [
+        { value: fmt(displayStats.total), label: 'Communes', accent: DSFR.text.actionHigh.blueFrance.default, valueColor: DSFR.text.actionHigh.blueFrance.default },
+        { value: fmt(displayStats.numeros), label: 'Numéros', accent: DSFR.text.actionHigh.blueCumulus.default, valueColor: DSFR.text.actionHigh.blueCumulus.default },
+        { value: fmt(displayStats.voies), label: 'Voies', accent: DSFR.text.actionHigh.greenArchipel.default, valueColor: DSFR.text.actionHigh.greenArchipel.default },
+      ]
+    : [
+        { value: fmt(displayStats.total), label: 'Communes', accent: DSFR.text.actionHigh.blueFrance.default, valueColor: DSFR.text.actionHigh.blueFrance.default },
+        { value: `${pct(displayStats.vert, total)}%`, label: 'Fiabilisés', accent: STATUS_TEXT_COLORS.vert, valueColor: STATUS_TEXT_COLORS.vert },
+        { value: fmt(displayStats.numeros), label: 'Numéros', accent: DSFR.text.actionHigh.blueCumulus.default, valueColor: DSFR.text.actionHigh.blueCumulus.default },
+        { value: fmt(displayStats.voies), label: 'Voies', accent: DSFR.text.actionHigh.greenArchipel.default, valueColor: DSFR.text.actionHigh.greenArchipel.default },
+      ]
+
+  return (
+    <StyledWrapper $inPanel={inPanel}>
+
+      {!activeDeptCode && (
+        <div className="global-search-wrapper">
+          <input
+            type="text"
+            className="global-search-input"
+            placeholder="Nom ou code INSEE"
+            value={globalSearch}
+            onChange={e => setGlobalSearch(e.target.value)}
+            autoComplete="off"
+          />
+          {globalSearchLoading && (
+            <div className="global-search-results">
+              <div className="search-result-loading">Recherche…</div>
+            </div>
+          )}
+          {!globalSearchLoading && globalSearchResults.length > 0 && (
+            <div className="global-search-results">
+              {globalSearchResults.map(r => (
+                <button
+                  key={r.code}
+                  type="button"
+                  className="search-result-item"
+                  onClick={async () => {
+                    setGlobalSearch('')
+                    setGlobalSearchResults([])
+                    try {
+                      const res = await fetch(`${SUIVI_BAN_API}/commune/${r.code}`)
+                      const full = res.ok ? await res.json() : null
+                      const commune = full ?? r
+                      if (onSearchSelect) onSearchSelect(commune)
+                      else onCommuneClick(commune)
+                    }
+                    catch {
+                      if (onSearchSelect) onSearchSelect(r)
+                      else onCommuneClick(r)
+                    }
+                  }}
+                >
+                  <span
+                    className="search-result-dot"
+                    style={{ background: STATUS_COLORS[r.statut] || STATUS_COLORS.gris }}
+                  />
+                  <span className="search-result-info">
+                    <span className="search-result-nom">{r.nom}</span>
+                    <span className="search-result-meta">{r.dept_nom} ({r.dept})</span>
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
+          {!globalSearchLoading && globalSearch.length >= 2 && globalSearchResults.length === 0 && (
+            <div className="global-search-results">
+              <div className="search-result-empty">Aucune commune trouvée</div>
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className={`stat-cards ${STAT_CARDS.length === 3 ? 'cards-3' : 'cards-4'}`}>
+        {STAT_CARDS.map(card => (
+          <div key={card.label} className="stat-card" style={{ borderTopColor: card.accent }}>
+            <span className="stat-card-value" style={{ color: card.valueColor }}>{card.value}</span>
+            <div className="stat-card-label">{card.label}</div>
+          </div>
+        ))}
+      </div>
+
+      {!activeDeptCode && (
+        <div style={{ marginBottom: '0.75rem' }}>
+          <div className="section-title" style={{ marginBottom: '0.35rem' }}>Mandataire</div>
+          <select
+            className={`producteur-select ${producteurFilter ? 'active' : ''}`}
+            style={{ maxWidth: '100%', width: '100%' }}
+            value={producteurFilter || ''}
+            disabled={allProducteurs.length === 0}
+            onChange={e => setProducteurFilter(e.target.value || null)}
+          >
+            <option value="">
+              {allProducteurs.length === 0 ? 'Chargement…' : 'Tous les mandataires'}
+            </option>
+            {allProducteurs.map(p => (
+              <option key={p.nom} value={p.nom}>
+                {p.nom} ({p.nb_communes} communes)
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      <div className="status-section">
+        <div className="status-bar">
+          {statuses.map(s => (
+            <div
+              key={s}
+              className="status-bar-segment"
+              style={{ width: `${pct(displayStats[s] ?? 0, total)}%`, background: STATUS_COLORS[s] }}
+            />
+          ))}
+        </div>
+        <div className="status-rows">
+          {statuses.map((s) => {
+            const isActive = activeStatuts.includes(s)
+            const isFiltering = activeStatuts.length < 4
+            const p = pct(displayStats[s] ?? 0, total)
+            if (activeDeptCode) {
+              return (
+                <button
+                  key={s}
+                  type="button"
+                  className={`status-row clickable ${isActive ? '' : 'inactive'}`}
+                  onClick={() => toggleStatut(s)}
+                >
+                  <span className="row-dot" style={{ background: STATUS_COLORS[s] }} />
+                  <span className="row-label">{STATUS_LABELS[s]}</span>
+                  <span className="row-count">{fmt(displayStats[s] ?? 0)}</span>
+                  <span className="row-pct">{p}%</span>
+                  {isFiltering && <span className={`row-check ${isActive ? 'on' : ''}`}>✓</span>}
+                </button>
+              )
+            }
+            return (
+              <div key={s} className="status-row">
+                <span className="row-dot" style={{ background: STATUS_COLORS[s] }} />
+                <span className="row-label">{STATUS_LABELS[s]}</span>
+                <span className="row-count">{fmt(displayStats[s] ?? 0)}</span>
+                <span className="row-pct">{p}%</span>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+      <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: '0.5rem' }}>
+        <button
+          type="button"
+          onClick={() => setShowStatusLegend(true)}
+          style={{
+            border: 'none',
+            background: 'none',
+            cursor: 'pointer',
+            fontSize: '0.8rem',
+            color: 'var(--text-default-grey)',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+          }}
+        >
+          <span
+            style={{
+              width: 18,
+              height: 18,
+              borderRadius: '50%',
+              border: '1px solid var(--border-default-grey)',
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: 11,
+              fontWeight: 700,
+            }}
+          >
+            i
+          </span>
+          <span>Comprendre les statuts</span>
+        </button>
+      </div>
+
+      {showStatusLegend && (
+        <div className="status-legend-overlay" onClick={() => setShowStatusLegend(false)}>
+          <div
+            className="status-legend-dialog"
+            onClick={e => e.stopPropagation()}
+          >
+            <div className="status-legend-title">Légende des statuts</div>
+            <div className="status-legend-content">
+              <div className="status-legend-row">
+                <span className="status-legend-dot" style={{ background: STATUS_COLORS.vert }} />
+                <span>
+                  <strong style={{ color: STATUS_TEXT_COLORS.vert }}>ID fiabilisés</strong> : les identifiants ont passé les contrôles d&apos;intégrité BAN, l&apos;historique est capitalisé sur ces données.
+                </span>
+              </div>
+              <div className="status-legend-row">
+                <span className="status-legend-dot" style={{ background: STATUS_COLORS.orange }} />
+                <span>
+                  <strong style={{ color: STATUS_TEXT_COLORS.orange }}>ID initiés à contrôler</strong> : les identifiants sont générés dans les BAL mais n&apos;ont pas encore intégré le dispositif de suivi de l&apos;historique.
+                </span>
+              </div>
+              <div className="status-legend-row">
+                <span className="status-legend-dot" style={{ background: STATUS_COLORS.rouge }} />
+                <span>
+                  <strong style={{ color: STATUS_TEXT_COLORS.rouge }}>ID non initiés</strong> : les identifiants n&apos;ont pas encore été générés dans la BAL.
+                </span>
+              </div>
+            </div>
+            <div style={{ marginTop: 12, textAlign: 'right' }}>
+              <button
+                type="button"
+                onClick={() => setShowStatusLegend(false)}
+                style={{
+                  border: 'none',
+                  background: 'var(--background-action-low-blue-france)',
+                  color: 'var(--text-action-high-blue-france)',
+                  padding: '6px 10px',
+                  borderRadius: 999,
+                  fontSize: '0.8rem',
+                  cursor: 'pointer',
+                  fontWeight: 600,
+                }}
+              >
+                Fermer
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {activeDeptCode && !loading && communes.length > 0 && (
+        <>
+          {filteredCommunes.length < communes.length && (
+            <div className="commune-list-header">
+              <p className="section-title" style={{ margin: 0 }}>
+                {filteredCommunes.length} / {communes.length} communes
+              </p>
+            </div>
+          )}
+
+          <div className="filters-row">
+            <input
+              type="text"
+              className="commune-search"
+              placeholder="Nom ou code INSEE"
+              value={communeSearch}
+              onChange={e => setCommuneSearch(e.target.value)}
+            />
+            {uniqueProducteurs.length > 0 && (
+              <select
+                className={`producteur-select ${producteurFilter ? 'active' : ''}`}
+                value={producteurFilter || ''}
+                onChange={e => setProducteurFilter(e.target.value || null)}
+              >
+                <option value="">Tous les mandataires</option>
+                {uniqueProducteurs.map(p => (
+                  <option key={p} value={p}>{p}</option>
+                ))}
+              </select>
+            )}
+          </div>
+
+          <div className="commune-list">
+            {filteredCommunes.length === 0
+              ? (
+                  <div style={{ padding: '1.5rem 1rem', color: 'var(--text-mention-grey)', textAlign: 'center', fontSize: '0.85rem' }}>
+                    Aucune commune pour ce filtre
+                  </div>
+                )
+              : (() => {
+                  const grouped = STATUS_ORDER
+                    .map(s => ({ statut: s, items: filteredCommunes.filter(c => (c.statut || 'gris') === s) }))
+                    .filter(g => g.items.length > 0)
+                  return grouped.map(group => (
+                    <div key={group.statut}>
+                      <div
+                        className="status-group-header"
+                        style={{
+                          background: STATUS_BG[group.statut],
+                          borderLeftColor: STATUS_TEXT_COLORS[group.statut],
+                          color: STATUS_TEXT_COLORS[group.statut],
+                        }}
+                      >
+                        <span>{inPanel ? STATUS_LABELS_SHORT[group.statut] : STATUS_LABELS[group.statut]}</span>
+                        <span
+                          className="group-count-badge"
+                          style={{ background: STATUS_TEXT_COLORS[group.statut], color: 'var(--text-inverted-grey)' }}
+                        >
+                          {group.items.length}
+                        </span>
+                      </div>
+                      {group.items.map((c) => {
+                        const color = STATUS_COLORS[c.statut] || STATUS_COLORS.gris
+                        return (
+                          <div
+                            key={c.code}
+                            className="commune-row"
+                            style={{ borderLeftColor: color }}
+                            onClick={() => onCommuneClick(c)}
+                            role="button"
+                            tabIndex={0}
+                            onKeyDown={e => e.key === 'Enter' && onCommuneClick(c)}
+                          >
+                            <span className="commune-main">
+                              <span className="commune-name">{c.nom}</span>
+                              {c.producteur && (
+                                <span className="commune-producteur">{c.producteur}</span>
+                              )}
+                            </span>
+                            <span className="commune-code">{c.code}</span>
+                            <span className="commune-numeros">{(c.nb_numeros || 0).toLocaleString('fr-FR')} num.</span>
+                          </div>
+                        )
+                      })}
+                    </div>
+                  ))
+                })()}
+          </div>
+        </>
+      )}
+
+      {filter?.type === 'EPCI' && !deptFilter && (
+        <p className="source-link" style={{ marginTop: '1rem', color: 'var(--text-default-warning)' }}>
+          ⚠️ Le filtre EPCI n&apos;est pas supporté par le Suivi BAN. Cliquez sur un département sur la carte ou sélectionnez un département.
+        </p>
+      )}
+
+      {!activeDeptCode && (
+        <p className="source-link" style={{ marginTop: '1rem' }}>
+          Cliquez sur un département pour voir le détail.
+        </p>
+      )}
+    </StyledWrapper>
+  )
+}

--- a/src/components/DeploiementBAL/TabSuiviBAN.tsx
+++ b/src/components/DeploiementBAL/TabSuiviBAN.tsx
@@ -70,6 +70,10 @@ interface Producteur {
 interface TabSuiviBanProps {
   filter: DeploiementBALSearchResult | null
   deptFilter: { code: string, nom: string } | null
+  deptCommunesMeta?: any[]
+  deptCommunesLoading?: boolean
+  deptCommunesError?: boolean
+  communeTilesEmpty?: boolean
   onCommuneClick: (commune: any) => void
   onSearchSelect?: (commune: any) => void
   activeStatuts?: string[]
@@ -548,11 +552,25 @@ function pct(value: number, total: number): number {
   return Math.round((value / total) * 1000) / 10
 }
 
-export default function TabSuiviBAN({ filter, deptFilter, onCommuneClick, onSearchSelect, activeStatuts: activeStatutsProp, onActiveStatutsChange, producteurFilter: producteurFilterProp, onProducteurFilterChange, allProducteurs = [], inPanel }: TabSuiviBanProps) {
-  const [stats, setStats] = useState<SuiviBanStats | null>(null)
-  const [communes, setCommunes] = useState<any[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState(false)
+export default function TabSuiviBAN({
+  filter,
+  deptFilter,
+  deptCommunesMeta = [],
+  deptCommunesLoading = false,
+  deptCommunesError = false,
+  communeTilesEmpty = false,
+  onCommuneClick,
+  onSearchSelect,
+  activeStatuts: activeStatutsProp,
+  onActiveStatutsChange,
+  producteurFilter: producteurFilterProp,
+  onProducteurFilterChange,
+  allProducteurs = [],
+  inPanel,
+}: TabSuiviBanProps) {
+  const [globalStats, setGlobalStats] = useState<SuiviBanStats | null>(null)
+  const [loadingGlobal, setLoadingGlobal] = useState(true)
+  const [errorGlobal, setErrorGlobal] = useState(false)
   const [activeStatutsLocal, setActiveStatutsLocal] = useState<string[]>(['rouge', 'orange', 'vert', 'gris'])
   const [communeSearch, setCommuneSearch] = useState('')
   const [producteurFilterLocal, setProducteurFilterLocal] = useState<string | null>(null)
@@ -584,52 +602,18 @@ export default function TabSuiviBAN({ filter, deptFilter, onCommuneClick, onSear
     setCommuneSearch('')
     setActiveStatutsLocal(['rouge', 'orange', 'vert', 'gris'])
     if (onChangeRef.current) onChangeRef.current(['rouge', 'orange', 'vert', 'gris'])
+  }, [activeDeptCode])
 
-    if (!activeDeptCode) {
-      setCommunes([])
+  useEffect(() => {
+    if (activeDeptCode) {
+      setLoadingGlobal(false)
+      setErrorGlobal(false)
       return
     }
 
     const controller = new AbortController()
-    setLoading(true)
-    setError(false)
-
-    fetch(`${SUIVI_BAN_API}/departement/${activeDeptCode}/communes`, { signal: controller.signal })
-      .then((r) => {
-        if (!r.ok) throw new Error('API error')
-        return r.json()
-      })
-      .then((data) => {
-        if (controller.signal.aborted) return
-        const features: any[] = data?.features || []
-        const counts: SuiviBanStats = { total: features.length, vert: 0, orange: 0, rouge: 0, gris: 0, numeros: 0, voies: 0 }
-        features.forEach((f: any) => {
-          const s = (f.properties?.statut || 'gris') as keyof SuiviBanStats
-          if (s in counts) (counts[s] as number)++
-          counts.numeros += f.properties?.nb_numeros || 0
-          counts.voies += f.properties?.nb_voies || 0
-        })
-        setStats(counts)
-        setCommunes(features.map(f => f.properties).sort((a, b) =>
-          STATUS_ORDER.indexOf(a.statut || 'gris') - STATUS_ORDER.indexOf(b.statut || 'gris')
-        ))
-      })
-      .catch((e: Error) => {
-        if (e.name !== 'AbortError') setError(true)
-      })
-      .finally(() => {
-        if (!controller.signal.aborted) setLoading(false)
-      })
-
-    return () => controller.abort()
-  }, [activeDeptCode])
-
-  useEffect(() => {
-    if (activeDeptCode) return
-
-    const controller = new AbortController()
-    setLoading(true)
-    setError(false)
+    setLoadingGlobal(true)
+    setErrorGlobal(false)
 
     const url = producteurFilter
       ? `${SUIVI_BAN_API}/producteur/${encodeURIComponent(producteurFilter)}/stats`
@@ -641,13 +625,13 @@ export default function TabSuiviBAN({ filter, deptFilter, onCommuneClick, onSear
         return r.json()
       })
       .then((data) => {
-        if (!controller.signal.aborted) setStats(data)
+        if (!controller.signal.aborted) setGlobalStats(data)
       })
       .catch((e: Error) => {
-        if (e.name !== 'AbortError') setError(true)
+        if (e.name !== 'AbortError') setErrorGlobal(true)
       })
       .finally(() => {
-        if (!controller.signal.aborted) setLoading(false)
+        if (!controller.signal.aborted) setLoadingGlobal(false)
       })
 
     return () => controller.abort()
@@ -684,8 +668,16 @@ export default function TabSuiviBAN({ filter, deptFilter, onCommuneClick, onSear
     )
   }
 
+  const communes = activeDeptCode
+    ? [...(deptCommunesMeta || [])].sort((a, b) =>
+        STATUS_ORDER.indexOf(a.statut || 'gris') - STATUS_ORDER.indexOf(b.statut || 'gris')
+      )
+    : []
+
+  const loading = activeDeptCode ? deptCommunesLoading : loadingGlobal
+  const error = activeDeptCode ? deptCommunesError : (errorGlobal || !globalStats)
   if (loading) return <StyledWrapper $inPanel={inPanel}><p className="loading">Chargement…</p></StyledWrapper>
-  if (error || !stats) return <StyledWrapper $inPanel={inPanel}><p className="error">Erreur de chargement.</p></StyledWrapper>
+  if (error) return <StyledWrapper $inPanel={inPanel}><p className="error">Erreur de chargement.</p></StyledWrapper>
 
   const statuses = ['vert', 'orange', 'rouge', 'gris'] as const
 
@@ -705,8 +697,10 @@ export default function TabSuiviBAN({ filter, deptFilter, onCommuneClick, onSear
   })
 
   const displayStats = (() => {
-    if (activeDeptCode && producteurFilter) {
-      const base = communes.filter(c => c.producteur === producteurFilter)
+    if (activeDeptCode) {
+      const base = producteurFilter
+        ? communes.filter(c => c.producteur === producteurFilter)
+        : communes
       return {
         total: base.length,
         vert: base.filter(c => c.statut === 'vert').length,
@@ -730,12 +724,12 @@ export default function TabSuiviBAN({ filter, deptFilter, onCommuneClick, onSear
           orange: o,
           rouge: r,
           gris: Math.max(0, t - v - o - r),
-          numeros: stats?.numeros || 0,
-          voies: stats?.voies || 0,
+          numeros: globalStats?.numeros || 0,
+          voies: globalStats?.voies || 0,
         }
       }
     }
-    return stats
+    return globalStats as SuiviBanStats
   })()
 
   const total = displayStats.total || 1
@@ -1061,6 +1055,18 @@ export default function TabSuiviBAN({ filter, deptFilter, onCommuneClick, onSear
                 })()}
           </div>
         </>
+      )}
+
+      {activeDeptCode && !loading && communes.length > 0 && communeTilesEmpty && (
+        <p className="source-link" style={{ marginTop: '0.75rem', color: 'var(--text-default-grey)' }}>
+          Certaines tuiles cartographiques sont vides à ce niveau de zoom, mais la liste metadata reste disponible.
+        </p>
+      )}
+
+      {activeDeptCode && !loading && communes.length === 0 && (
+        <p className="source-link" style={{ marginTop: '0.75rem', color: 'var(--text-default-grey)' }}>
+          Aucune commune metadata disponible pour ce département.
+        </p>
       )}
 
       {filter?.type === 'EPCI' && !deptFilter && (

--- a/src/components/DeploiementBAL/useSuiviBan.ts
+++ b/src/components/DeploiementBAL/useSuiviBan.ts
@@ -1,0 +1,372 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { MapRef } from 'react-map-gl/maplibre'
+
+import { fr } from '@codegouvfr/react-dsfr'
+
+const SUIVI_BAN_API = process.env.NEXT_PUBLIC_SUIVI_BAN_API_URL || 'https://suivi-ban.mut-dev.ign.fr/api'
+
+const DSFR_HEX = fr.colors.getHex({ isDark: false }).decisions
+
+const DEPT_STATUS_COLORS: Record<string, string> = {
+  vert: DSFR_HEX.text.default.success.default,
+  orange: DSFR_HEX.text.default.warning.default,
+  rouge: DSFR_HEX.text.default.error.default,
+  gris: DSFR_HEX.text.default.grey.default,
+}
+
+const TERRITOIRES: Record<string, { lat: number, lon: number, zoom: number, nom: string }> = {
+  971: { lat: 16.265, lon: -61.551, zoom: 9, nom: 'Guadeloupe' },
+  972: { lat: 14.641, lon: -61.024, zoom: 10, nom: 'Martinique' },
+  973: { lat: 3.933, lon: -53.125, zoom: 7, nom: 'Guyane' },
+  974: { lat: -21.115, lon: 55.536, zoom: 10, nom: 'La Réunion' },
+  976: { lat: -12.827, lon: 45.166, zoom: 10, nom: 'Mayotte' },
+  975: { lat: 46.833, lon: -56.333, zoom: 7, nom: 'Saint-Pierre-et-Miquelon' },
+  977: { lat: 17.900, lon: -62.833, zoom: 11, nom: 'Saint-Barthélemy' },
+  978: { lat: 18.070, lon: -63.050, zoom: 11, nom: 'Saint-Martin' },
+  988: { lat: -22.276, lon: 166.457, zoom: 7, nom: 'Nouvelle-Calédonie' },
+  987: { lat: -17.679, lon: -149.406, zoom: 7, nom: 'Polynésie française' },
+  986: { lat: -13.293, lon: -176.199, zoom: 7, nom: 'Wallis-et-Futuna' },
+}
+
+export type SuiviBanSelectedDept = { code: string, nom: string }
+
+export type HoveredDept = {
+  code: string
+  nom: string
+  vert: number
+  orange: number
+  rouge: number
+  gris: number
+  total: number
+  x: number
+  y: number
+}
+
+export type HoveredCommune = {
+  code: string
+  nom: string
+  statut: string
+  nb_numeros: number
+  nb_voies: number
+  producteur?: string
+  x: number
+  y: number
+}
+
+function getBoundsFromGeometry(geometry: any): [[number, number], [number, number]] {
+  let minLng = Infinity, minLat = Infinity, maxLng = -Infinity, maxLat = -Infinity
+  function processCoords(coords: any) {
+    if (typeof coords[0] === 'number') {
+      minLng = Math.min(minLng, coords[0])
+      maxLng = Math.max(maxLng, coords[0])
+      minLat = Math.min(minLat, coords[1])
+      maxLat = Math.max(maxLat, coords[1])
+    }
+    else {
+      coords.forEach(processCoords)
+    }
+  }
+  processCoords(geometry.coordinates)
+  return [[minLng, minLat], [maxLng, maxLat]]
+}
+
+function getCommuneCoordinates(commune: any): [number, number] | null {
+  const lon = Number(commune?.lon)
+  const lat = Number(commune?.lat)
+  return Number.isFinite(lon) && Number.isFinite(lat) ? [lon, lat] : null
+}
+
+interface UseSuiviBanOptions {
+  selectedTab: string
+}
+
+export function useSuiviBan({ selectedTab }: UseSuiviBanOptions) {
+  const mapRef = useRef<MapRef>(null)
+  const mapContainerRef = useRef<HTMLDivElement>(null)
+  const [suiviBanGeoJSON, setSuiviBanGeoJSON] = useState<any>(null)
+  const [suiviBanSelectedDept, setSuiviBanSelectedDept] = useState<SuiviBanSelectedDept | null>(null)
+  const [suiviBanCommunesGeoJSON, setSuiviBanCommunesGeoJSON] = useState<any>(null)
+  const [suiviBanLoadingCommunes, setSuiviBanLoadingCommunes] = useState(false)
+  const [suiviBanSelectedCommune, setSuiviBanSelectedCommune] = useState<any>(null)
+  const [suiviBanActiveStatuts, setSuiviBanActiveStatuts] = useState<string[]>(['rouge', 'orange', 'vert', 'gris'])
+  const [suiviBanProducteurFilter, setSuiviBanProducteurFilter] = useState<string | null>(null)
+  const [suiviBanProducteurs, setSuiviBanProducteurs] = useState<any[]>([])
+  const [hoveredDept, setHoveredDept] = useState<HoveredDept | null>(null)
+  const [hoveredCommune, setHoveredCommune] = useState<HoveredCommune | null>(null)
+  const deptsGeometryRef = useRef<any>(null)
+
+  useEffect(() => {
+    if (selectedTab !== 'suivi-ban' || suiviBanProducteurs.length > 0) return
+    fetch(`${SUIVI_BAN_API}/producteurs`)
+      .then(r => r.json())
+      .then(data => setSuiviBanProducteurs(data || []))
+      .catch(e => console.error('Producteurs load error:', e))
+  }, [selectedTab, suiviBanProducteurs.length])
+
+  useEffect(() => {
+    if (selectedTab !== 'suivi-ban' || suiviBanSelectedDept) return
+    async function loadDepts() {
+      try {
+        if (!deptsGeometryRef.current) {
+          const res = await fetch(`${SUIVI_BAN_API}/departements`)
+          deptsGeometryRef.current = await res.json()
+        }
+        const depts = deptsGeometryRef.current
+        const statsUrl = suiviBanProducteurFilter
+          ? `${SUIVI_BAN_API}/producteur/${encodeURIComponent(suiviBanProducteurFilter)}/departements`
+          : `${SUIVI_BAN_API}/stats/departements`
+        const stats = await fetch(statsUrl).then(r => r.json())
+        const statusOrder = ['vert', 'orange', 'rouge', 'gris'] as const
+        const geojson = {
+          ...depts,
+          features: (depts.features || []).map((f: any) => {
+            const deptStats = stats[f.properties.code]
+            let dominantColor: string = DSFR_HEX.background.alt.grey.default
+            let dominantOpacity = 0.4
+            if (deptStats && deptStats.total > 0) {
+              const sorted = statusOrder
+                .map(key => ({ key, value: deptStats[key] || 0 }))
+                .sort((a, b) => b.value - a.value)
+              const activeTotal = sorted.reduce((sum, s) => sum + s.value, 0)
+              if (activeTotal > 0) {
+                const dominant = sorted[0]
+                dominantColor = DEPT_STATUS_COLORS[dominant.key] || DSFR_HEX.background.alt.grey.default
+                dominantOpacity = 0.3 + (dominant.value / activeTotal) * 0.55
+              }
+            }
+            return {
+              ...f,
+              properties: { ...f.properties, ...(deptStats || {}), dominant_color: dominantColor, dominant_opacity: dominantOpacity },
+            }
+          }),
+        }
+        setSuiviBanGeoJSON(geojson)
+      }
+      catch (e) {
+        console.error('Suivi BAN depts error:', e)
+      }
+    }
+    loadDepts()
+  }, [selectedTab, suiviBanProducteurFilter, suiviBanSelectedDept])
+
+  useEffect(() => {
+    if (!suiviBanSelectedDept) return
+    const controller = new AbortController()
+    setSuiviBanCommunesGeoJSON(null)
+    setSuiviBanLoadingCommunes(true)
+    fetch(`${SUIVI_BAN_API}/departement/${suiviBanSelectedDept.code}/communes`, { signal: controller.signal })
+      .then(r => r.json())
+      .then(data => setSuiviBanCommunesGeoJSON(data))
+      .catch((e: Error) => {
+        if (e.name !== 'AbortError') {
+          console.error('Communes load error:', e)
+        }
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setSuiviBanLoadingCommunes(false)
+        }
+      })
+    return () => controller.abort()
+  }, [suiviBanSelectedDept])
+
+  useEffect(() => {
+    if (selectedTab !== 'suivi-ban' || suiviBanSelectedDept) {
+      setHoveredDept(null)
+      return
+    }
+    const map = mapRef.current?.getMap()
+    if (!map) return
+
+    const onMouseMove = (e: any) => {
+      if (!map.getLayer('suivi-ban-dept-fill')) return
+      const features = map.queryRenderedFeatures(e.point, { layers: ['suivi-ban-dept-fill'] })
+      if (features.length > 0) {
+        const p = features[0].properties as any
+        const total = Number(p.total || 0)
+        setHoveredDept({
+          code: p.code,
+          nom: p.nom || p.code,
+          vert: Number(p.vert || 0),
+          orange: Number(p.orange || 0),
+          rouge: Number(p.rouge || 0),
+          gris: Number(p.gris || 0),
+          total,
+          x: e.point.x,
+          y: e.point.y,
+        })
+      }
+      else {
+        setHoveredDept(null)
+      }
+    }
+
+    const onMouseLeave = () => setHoveredDept(null)
+
+    map.on('mousemove', onMouseMove)
+    map.on('mouseout', onMouseLeave)
+
+    return () => {
+      map.off('mousemove', onMouseMove)
+      map.off('mouseout', onMouseLeave)
+      setHoveredDept(null)
+    }
+  }, [selectedTab, suiviBanSelectedDept])
+
+  useEffect(() => {
+    if (selectedTab !== 'suivi-ban' || !suiviBanSelectedDept) {
+      setHoveredCommune(null)
+      return
+    }
+    const map = mapRef.current?.getMap()
+    if (!map) return
+
+    const onMouseMove = (e: any) => {
+      if (!map.getLayer('suivi-ban-commune-fill')) return
+      const features = map.queryRenderedFeatures(e.point, { layers: ['suivi-ban-commune-fill'] })
+      if (features.length > 0) {
+        const p = features[0].properties as any
+        setHoveredCommune({
+          code: p.code,
+          nom: p.nom || p.code,
+          statut: p.statut || 'gris',
+          nb_numeros: Number(p.nb_numeros || 0),
+          nb_voies: Number(p.nb_voies || 0),
+          producteur: p.producteur,
+          x: e.point.x,
+          y: e.point.y,
+        })
+      }
+      else {
+        setHoveredCommune(null)
+      }
+    }
+
+    const onMouseLeave = () => setHoveredCommune(null)
+
+    map.on('mousemove', onMouseMove)
+    map.on('mouseout', onMouseLeave)
+
+    return () => {
+      map.off('mousemove', onMouseMove)
+      map.off('mouseout', onMouseLeave)
+      setHoveredCommune(null)
+    }
+  }, [selectedTab, suiviBanSelectedDept])
+
+  const handleMapClick = useCallback((e: any) => {
+    if (selectedTab !== 'suivi-ban') return
+    const features = e.features || []
+
+    const communeFeature = features.find((f: any) => f.layer?.id === 'suivi-ban-commune-fill')
+    if (communeFeature?.properties) {
+      setSuiviBanSelectedCommune(communeFeature.properties)
+      return
+    }
+
+    const deptFeature = features.find((f: any) => f.layer?.id === 'suivi-ban-dept-fill')
+    if (deptFeature?.geometry?.coordinates) {
+      const { code, nom } = deptFeature.properties
+      const isNewDept = !suiviBanSelectedDept || suiviBanSelectedDept.code !== code
+      if (isNewDept) {
+        setSuiviBanSelectedDept({ code, nom })
+        setSuiviBanSelectedCommune(null)
+        const bounds = getBoundsFromGeometry(deptFeature.geometry)
+        mapRef.current?.fitBounds(bounds, { padding: 40, duration: 800 })
+      }
+      return
+    }
+
+    if (suiviBanSelectedDept) {
+      setSuiviBanSelectedCommune(null)
+      return
+    }
+  }, [selectedTab, suiviBanSelectedDept, mapRef])
+
+  const handleCommuneClick = useCallback((commune: any) => {
+    setSuiviBanSelectedCommune(commune)
+    const coordinates = getCommuneCoordinates(commune)
+    if (coordinates) {
+      mapRef.current?.flyTo({ center: coordinates, zoom: 13, duration: 600 })
+    }
+  }, [mapRef])
+
+  const handleSearchSelect = useCallback((commune: any) => {
+    if (commune.dept && commune.dept_nom) {
+      setSuiviBanSelectedDept({ code: commune.dept, nom: commune.dept_nom })
+      setSuiviBanCommunesGeoJSON(null)
+    }
+    setSuiviBanSelectedCommune(commune)
+    const coordinates = getCommuneCoordinates(commune)
+    if (coordinates) {
+      mapRef.current?.flyTo({ center: coordinates, zoom: 12, duration: 800 })
+    }
+  }, [mapRef])
+
+  const handleTerritorySelect = useCallback((code: string) => {
+    if (!code) return
+    const territoire = TERRITOIRES[code]
+    if (!territoire) return
+    mapRef.current?.flyTo({ center: [territoire.lon, territoire.lat], zoom: territoire.zoom, duration: 1000 })
+    setSuiviBanSelectedDept({ code, nom: territoire.nom })
+    setSuiviBanCommunesGeoJSON(null)
+    setSuiviBanSelectedCommune(null)
+  }, [mapRef])
+
+  const handleBack = useCallback(() => {
+    setSuiviBanSelectedDept(null)
+    setSuiviBanCommunesGeoJSON(null)
+    setSuiviBanSelectedCommune(null)
+    setSuiviBanActiveStatuts(['rouge', 'orange', 'vert', 'gris'])
+    setSuiviBanProducteurFilter(null)
+    mapRef.current?.flyTo({ center: [2, 47], zoom: 5, duration: 800 })
+  }, [mapRef])
+
+  const balPaintLayer: 'source' | 'bal' = selectedTab === 'suivi-ban'
+    ? 'source'
+    : (selectedTab as 'source' | 'bal')
+
+  useEffect(() => {
+    const map = mapRef.current?.getMap()
+    if (!map) return
+    const visibility = selectedTab === 'suivi-ban' ? 'none' : 'visible'
+    const apply = () => {
+      if (map.getLayer('bal-polygon-fill')) {
+        map.setLayoutProperty('bal-polygon-fill', 'visibility', visibility)
+      }
+    }
+    if (map.isStyleLoaded()) apply()
+    else map.once('styledata', apply)
+  }, [selectedTab])
+
+  const interactiveLayerIds = suiviBanSelectedDept
+    ? ['suivi-ban-commune-fill']
+    : ['suivi-ban-dept-fill']
+
+  return {
+    mapRef,
+    mapContainerRef,
+    interactiveLayerIds,
+    balPaintLayer,
+    suiviBanGeoJSON,
+    suiviBanSelectedDept,
+    suiviBanCommunesGeoJSON,
+    suiviBanLoadingCommunes,
+    suiviBanSelectedCommune,
+    setSuiviBanSelectedCommune,
+    suiviBanActiveStatuts,
+    setSuiviBanActiveStatuts,
+    suiviBanProducteurFilter,
+    setSuiviBanProducteurFilter,
+    suiviBanProducteurs,
+    handleMapClick,
+    handleCommuneClick,
+    handleSearchSelect,
+    handleTerritorySelect,
+    handleBack,
+    hoveredDept,
+    hoveredCommune,
+  }
+}
+
+export type SuiviBanContext = ReturnType<typeof useSuiviBan>

--- a/src/components/DeploiementBAL/useSuiviBan.ts
+++ b/src/components/DeploiementBAL/useSuiviBan.ts
@@ -1,18 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { MapRef } from 'react-map-gl/maplibre'
 
-import { fr } from '@codegouvfr/react-dsfr'
-
 const SUIVI_BAN_API = process.env.NEXT_PUBLIC_SUIVI_BAN_API_URL || 'https://suivi-ban.mut-dev.ign.fr/api'
-
-const DSFR_HEX = fr.colors.getHex({ isDark: false }).decisions
-
-const DEPT_STATUS_COLORS: Record<string, string> = {
-  vert: DSFR_HEX.text.default.success.default,
-  orange: DSFR_HEX.text.default.warning.default,
-  rouge: DSFR_HEX.text.default.error.default,
-  gris: DSFR_HEX.text.default.grey.default,
-}
+const ENABLE_HOVER = true
 
 const TERRITOIRES: Record<string, { lat: number, lon: number, zoom: number, nom: string }> = {
   971: { lat: 16.265, lon: -61.551, zoom: 9, nom: 'Guadeloupe' },
@@ -53,27 +43,80 @@ export type HoveredCommune = {
   y: number
 }
 
-function getBoundsFromGeometry(geometry: any): [[number, number], [number, number]] {
-  let minLng = Infinity, minLat = Infinity, maxLng = -Infinity, maxLat = -Infinity
-  function processCoords(coords: any) {
-    if (typeof coords[0] === 'number') {
-      minLng = Math.min(minLng, coords[0])
-      maxLng = Math.max(maxLng, coords[0])
-      minLat = Math.min(minLat, coords[1])
-      maxLat = Math.max(maxLat, coords[1])
-    }
-    else {
-      coords.forEach(processCoords)
-    }
-  }
-  processCoords(geometry.coordinates)
-  return [[minLng, minLat], [maxLng, maxLat]]
+type DeptStats = {
+  total: number
+  vert: number
+  orange: number
+  rouge: number
+  gris: number
 }
+
+type Bounds = [[number, number], [number, number]]
 
 function getCommuneCoordinates(commune: any): [number, number] | null {
   const lon = Number(commune?.lon)
   const lat = Number(commune?.lat)
   return Number.isFinite(lon) && Number.isFinite(lat) ? [lon, lat] : null
+}
+
+function normalizeCode(code: unknown): string {
+  const raw = String(code || '').trim().toUpperCase()
+  if (raw === '2A' || raw === '2B') return raw
+  if (/^\d+$/.test(raw)) {
+    if (raw.length === 1) return raw.padStart(2, '0')
+    return raw
+  }
+  return raw
+}
+
+function toNumber(value: unknown): number {
+  const n = Number(value || 0)
+  return Number.isFinite(n) ? n : 0
+}
+
+function normalizeDeptStatsMap(input: Record<string, any>): Record<string, DeptStats> {
+  const output: Record<string, DeptStats> = {}
+  Object.entries(input || {}).forEach(([rawCode, value]) => {
+    const code = normalizeCode(rawCode)
+    output[code] = {
+      total: toNumber(value?.total),
+      vert: toNumber(value?.vert),
+      orange: toNumber(value?.orange),
+      rouge: toNumber(value?.rouge),
+      gris: toNumber(value?.gris),
+    }
+  })
+  return output
+}
+
+function normalizeBounds(raw: any): Bounds | null {
+  if (raw && Array.isArray(raw.southwest) && Array.isArray(raw.northeast)) {
+    const sw = raw.southwest.map(Number)
+    const ne = raw.northeast.map(Number)
+    if (sw.length >= 2 && ne.length >= 2 && Number.isFinite(sw[0]) && Number.isFinite(sw[1]) && Number.isFinite(ne[0]) && Number.isFinite(ne[1])) {
+      return [[Math.min(sw[1], ne[1]), Math.min(sw[0], ne[0])], [Math.max(sw[1], ne[1]), Math.max(sw[0], ne[0])]]
+    }
+  }
+
+  if (!Array.isArray(raw) || raw.length !== 2 || !Array.isArray(raw[0]) || !Array.isArray(raw[1])) {
+    return null
+  }
+
+  const p1 = raw[0].map(Number)
+  const p2 = raw[1].map(Number)
+  if (p1.length < 2 || p2.length < 2 || !Number.isFinite(p1[0]) || !Number.isFinite(p1[1]) || !Number.isFinite(p2[0]) || !Number.isFinite(p2[1])) {
+    return null
+  }
+
+  const looksLikeLatLng = Math.abs(p1[0]) <= 90 && Math.abs(p1[1]) <= 180 && Math.abs(p2[0]) <= 90 && Math.abs(p2[1]) <= 180
+  const sw: [number, number] = looksLikeLatLng ? [p1[1], p1[0]] : [p1[0], p1[1]]
+  const ne: [number, number] = looksLikeLatLng ? [p2[1], p2[0]] : [p2[0], p2[1]]
+
+  const minLng = Math.min(sw[0], ne[0])
+  const minLat = Math.min(sw[1], ne[1])
+  const maxLng = Math.max(sw[0], ne[0])
+  const maxLat = Math.max(sw[1], ne[1])
+  return [[minLng, minLat], [maxLng, maxLat]]
 }
 
 interface UseSuiviBanOptions {
@@ -83,17 +126,25 @@ interface UseSuiviBanOptions {
 export function useSuiviBan({ selectedTab }: UseSuiviBanOptions) {
   const mapRef = useRef<MapRef>(null)
   const mapContainerRef = useRef<HTMLDivElement>(null)
-  const [suiviBanGeoJSON, setSuiviBanGeoJSON] = useState<any>(null)
   const [suiviBanSelectedDept, setSuiviBanSelectedDept] = useState<SuiviBanSelectedDept | null>(null)
-  const [suiviBanCommunesGeoJSON, setSuiviBanCommunesGeoJSON] = useState<any>(null)
+  const [suiviBanDeptStats, setSuiviBanDeptStats] = useState<Record<string, DeptStats>>({})
+  const [suiviBanCommunesMeta, setSuiviBanCommunesMeta] = useState<any[]>([])
   const [suiviBanLoadingCommunes, setSuiviBanLoadingCommunes] = useState(false)
+  const [suiviBanCommunesError, setSuiviBanCommunesError] = useState(false)
+  const [suiviBanCommuneTilesEmpty, setSuiviBanCommuneTilesEmpty] = useState(false)
   const [suiviBanSelectedCommune, setSuiviBanSelectedCommune] = useState<any>(null)
   const [suiviBanActiveStatuts, setSuiviBanActiveStatuts] = useState<string[]>(['rouge', 'orange', 'vert', 'gris'])
   const [suiviBanProducteurFilter, setSuiviBanProducteurFilter] = useState<string | null>(null)
   const [suiviBanProducteurs, setSuiviBanProducteurs] = useState<any[]>([])
   const [hoveredDept, setHoveredDept] = useState<HoveredDept | null>(null)
   const [hoveredCommune, setHoveredCommune] = useState<HoveredCommune | null>(null)
-  const deptsGeometryRef = useRef<any>(null)
+  const deptStatsCacheRef = useRef<Map<string, Record<string, DeptStats>>>(new Map())
+  const boundsCacheRef = useRef<Map<string, Bounds | null>>(new Map())
+  const communesMetaCacheRef = useRef<Map<string, any[]>>(new Map())
+  const skipNextFitBoundsRef = useRef(false)
+  const hoveredDeptCodeRef = useRef<string | null>(null)
+  const hoveredCommuneCodeRef = useRef<string | null>(null)
+  const isMapNavigatingRef = useRef(false)
 
   useEffect(() => {
     if (selectedTab !== 'suivi-ban' || suiviBanProducteurs.length > 0) return
@@ -104,62 +155,111 @@ export function useSuiviBan({ selectedTab }: UseSuiviBanOptions) {
   }, [selectedTab, suiviBanProducteurs.length])
 
   useEffect(() => {
-    if (selectedTab !== 'suivi-ban' || suiviBanSelectedDept) return
-    async function loadDepts() {
+    if (selectedTab !== 'suivi-ban') return
+
+    const cacheKey = suiviBanProducteurFilter || '__all__'
+    const cached = deptStatsCacheRef.current.get(cacheKey)
+    if (cached) {
+      setSuiviBanDeptStats(cached)
+      return
+    }
+
+    let cancelled = false
+    async function loadDeptStats() {
       try {
-        if (!deptsGeometryRef.current) {
-          const res = await fetch(`${SUIVI_BAN_API}/departements`)
-          deptsGeometryRef.current = await res.json()
-        }
-        const depts = deptsGeometryRef.current
         const statsUrl = suiviBanProducteurFilter
           ? `${SUIVI_BAN_API}/producteur/${encodeURIComponent(suiviBanProducteurFilter)}/departements`
           : `${SUIVI_BAN_API}/stats/departements`
-        const stats = await fetch(statsUrl).then(r => r.json())
-        const statusOrder = ['vert', 'orange', 'rouge', 'gris'] as const
-        const geojson = {
-          ...depts,
-          features: (depts.features || []).map((f: any) => {
-            const deptStats = stats[f.properties.code]
-            let dominantColor: string = DSFR_HEX.background.alt.grey.default
-            let dominantOpacity = 0.4
-            if (deptStats && deptStats.total > 0) {
-              const sorted = statusOrder
-                .map(key => ({ key, value: deptStats[key] || 0 }))
-                .sort((a, b) => b.value - a.value)
-              const activeTotal = sorted.reduce((sum, s) => sum + s.value, 0)
-              if (activeTotal > 0) {
-                const dominant = sorted[0]
-                dominantColor = DEPT_STATUS_COLORS[dominant.key] || DSFR_HEX.background.alt.grey.default
-                dominantOpacity = 0.3 + (dominant.value / activeTotal) * 0.55
-              }
-            }
-            return {
-              ...f,
-              properties: { ...f.properties, ...(deptStats || {}), dominant_color: dominantColor, dominant_opacity: dominantOpacity },
-            }
-          }),
-        }
-        setSuiviBanGeoJSON(geojson)
+        const res = await fetch(statsUrl)
+        if (!res.ok) throw new Error(`Stats départements HTTP ${res.status}`)
+        const data = await res.json()
+        if (cancelled) return
+
+        const normalized = normalizeDeptStatsMap(data || {})
+        deptStatsCacheRef.current.set(cacheKey, normalized)
+        setSuiviBanDeptStats(normalized)
       }
       catch (e) {
-        console.error('Suivi BAN depts error:', e)
+        console.error('Suivi BAN stats départements error:', e)
       }
     }
-    loadDepts()
-  }, [selectedTab, suiviBanProducteurFilter, suiviBanSelectedDept])
+    loadDeptStats()
+
+    return () => {
+      cancelled = true
+    }
+  }, [selectedTab, suiviBanProducteurFilter])
 
   useEffect(() => {
     if (!suiviBanSelectedDept) return
+
     const controller = new AbortController()
-    setSuiviBanCommunesGeoJSON(null)
     setSuiviBanLoadingCommunes(true)
-    fetch(`${SUIVI_BAN_API}/departement/${suiviBanSelectedDept.code}/communes`, { signal: controller.signal })
-      .then(r => r.json())
-      .then(data => setSuiviBanCommunesGeoJSON(data))
-      .catch((e: Error) => {
-        if (e.name !== 'AbortError') {
-          console.error('Communes load error:', e)
+    setSuiviBanCommunesError(false)
+    setSuiviBanCommuneTilesEmpty(false)
+
+    const deptCode = normalizeCode(suiviBanSelectedDept.code)
+
+    const loadBounds = async (): Promise<Bounds | null> => {
+      if (boundsCacheRef.current.has(deptCode)) {
+        return boundsCacheRef.current.get(deptCode) ?? null
+      }
+      const response = await fetch(`${SUIVI_BAN_API}/departement/${deptCode}/bounds`, { signal: controller.signal })
+      if (!response.ok) {
+        boundsCacheRef.current.set(deptCode, null)
+        return null
+      }
+      const rawBounds = await response.json()
+      const normalized = normalizeBounds(rawBounds)
+      boundsCacheRef.current.set(deptCode, normalized)
+      return normalized
+    }
+
+    const loadCommunesMeta = async (): Promise<any[]> => {
+      const cached = communesMetaCacheRef.current.get(deptCode)
+      if (cached) return cached
+      const response = await fetch(`${SUIVI_BAN_API}/departement/${deptCode}/communes-meta`, { signal: controller.signal })
+      if (!response.ok) {
+        throw new Error(`Communes meta API error (${response.status})`)
+      }
+      const payload = await response.json()
+      const list = Array.isArray(payload)
+        ? payload
+        : (Array.isArray(payload?.communes) ? payload.communes : [])
+      communesMetaCacheRef.current.set(deptCode, list)
+      return list
+    }
+
+    Promise.allSettled([loadBounds(), loadCommunesMeta()])
+      .then(([boundsResult, communesMetaResult]) => {
+        if (controller.signal.aborted) return
+
+        if (communesMetaResult.status === 'fulfilled') {
+          setSuiviBanCommunesMeta(communesMetaResult.value)
+          setSuiviBanCommunesError(false)
+        }
+        else {
+          const err = communesMetaResult.reason as Error
+          if (err?.name !== 'AbortError') {
+            console.error('Département communes-meta load error:', err)
+            setSuiviBanCommunesError(true)
+          }
+        }
+
+        if (boundsResult.status === 'fulfilled') {
+          const bounds = boundsResult.value
+          if (bounds) {
+            if (!skipNextFitBoundsRef.current) {
+              mapRef.current?.fitBounds(bounds, { padding: 40, duration: 800 })
+            }
+            skipNextFitBoundsRef.current = false
+          }
+        }
+        else {
+          const err = boundsResult.reason as Error
+          if (err?.name !== 'AbortError') {
+            console.warn('Département bounds load error:', deptCode, err?.message || err)
+          }
         }
       })
       .finally(() => {
@@ -167,92 +267,309 @@ export function useSuiviBan({ selectedTab }: UseSuiviBanOptions) {
           setSuiviBanLoadingCommunes(false)
         }
       })
+
     return () => controller.abort()
   }, [suiviBanSelectedDept])
 
   useEffect(() => {
-    if (selectedTab !== 'suivi-ban' || suiviBanSelectedDept) {
-      setHoveredDept(null)
+    if (!ENABLE_HOVER) return
+    if (selectedTab !== 'suivi-ban') {
+      isMapNavigatingRef.current = false
       return
     }
     const map = mapRef.current?.getMap()
     if (!map) return
 
-    const onMouseMove = (e: any) => {
-      if (!map.getLayer('suivi-ban-dept-fill')) return
-      const features = map.queryRenderedFeatures(e.point, { layers: ['suivi-ban-dept-fill'] })
-      if (features.length > 0) {
-        const p = features[0].properties as any
-        const total = Number(p.total || 0)
-        setHoveredDept({
-          code: p.code,
-          nom: p.nom || p.code,
-          vert: Number(p.vert || 0),
-          orange: Number(p.orange || 0),
-          rouge: Number(p.rouge || 0),
-          gris: Number(p.gris || 0),
-          total,
-          x: e.point.x,
-          y: e.point.y,
-        })
+    let releaseTimer: ReturnType<typeof setTimeout> | null = null
+    const lockNavigation = () => {
+      isMapNavigatingRef.current = true
+      setHoveredDept(null)
+      setHoveredCommune(null)
+      hoveredDeptCodeRef.current = null
+      hoveredCommuneCodeRef.current = null
+      if (releaseTimer) {
+        clearTimeout(releaseTimer)
+        releaseTimer = null
       }
-      else {
-        setHoveredDept(null)
+    }
+    const unlockNavigationSoon = () => {
+      if (releaseTimer) clearTimeout(releaseTimer)
+      releaseTimer = setTimeout(() => {
+        isMapNavigatingRef.current = false
+      }, 120)
+    }
+
+    map.on('movestart', lockNavigation)
+    map.on('zoomstart', lockNavigation)
+    map.on('pitchstart', lockNavigation)
+    map.on('rotatestart', lockNavigation)
+    map.on('moveend', unlockNavigationSoon)
+    map.on('zoomend', unlockNavigationSoon)
+    map.on('idle', unlockNavigationSoon)
+
+    return () => {
+      map.off('movestart', lockNavigation)
+      map.off('zoomstart', lockNavigation)
+      map.off('pitchstart', lockNavigation)
+      map.off('rotatestart', lockNavigation)
+      map.off('moveend', unlockNavigationSoon)
+      map.off('zoomend', unlockNavigationSoon)
+      map.off('idle', unlockNavigationSoon)
+      if (releaseTimer) clearTimeout(releaseTimer)
+      isMapNavigatingRef.current = false
+    }
+  }, [selectedTab])
+
+  useEffect(() => {
+    if (!ENABLE_HOVER) {
+      setHoveredDept(null)
+      hoveredDeptCodeRef.current = null
+      return
+    }
+    if (selectedTab !== 'suivi-ban' || suiviBanSelectedDept) {
+      setHoveredDept(null)
+      hoveredDeptCodeRef.current = null
+      return
+    }
+    const map = mapRef.current?.getMap()
+    if (!map) return
+
+    let rafId: number | null = null
+    let queuedHover: HoveredDept | null = null
+    const flushHover = () => {
+      setHoveredDept(queuedHover)
+      rafId = null
+    }
+
+    const queueHoverUpdate = (next: HoveredDept | null) => {
+      queuedHover = next
+      if (rafId === null) {
+        rafId = window.requestAnimationFrame(flushHover)
       }
     }
 
-    const onMouseLeave = () => setHoveredDept(null)
+    const onLayerMove = (e: any) => {
+      if (isMapNavigatingRef.current || map.isMoving() || map.isZooming()) {
+        clearDeptHover()
+        return
+      }
+      const feature = e.features?.[0]
+      if (!feature?.properties) return
+      const p = feature.properties as any
+      const code = normalizeCode(p.code)
+      const stats = suiviBanDeptStats[code] || { vert: 0, orange: 0, rouge: 0, gris: 0, total: 0 }
+      hoveredDeptCodeRef.current = code
+      queueHoverUpdate({
+        code,
+        nom: p.nom || code,
+        vert: toNumber(stats.vert),
+        orange: toNumber(stats.orange),
+        rouge: toNumber(stats.rouge),
+        gris: toNumber(stats.gris),
+        total: toNumber(stats.total),
+        x: e.point.x,
+        y: e.point.y,
+      })
+    }
 
-    map.on('mousemove', onMouseMove)
-    map.on('mouseout', onMouseLeave)
+    const clearDeptHover = () => {
+      hoveredDeptCodeRef.current = null
+      queueHoverUpdate(null)
+    }
+
+    const bindIfReady = () => {
+      if (!map.getLayer('suivi-ban-dept-fill')) return false
+      map.on('mousemove', 'suivi-ban-dept-fill', onLayerMove)
+      map.on('mouseleave', 'suivi-ban-dept-fill', clearDeptHover)
+      map.on('zoomstart', clearDeptHover)
+      map.on('movestart', clearDeptHover)
+      return true
+    }
+
+    if (!bindIfReady()) {
+      map.once('styledata', bindIfReady)
+    }
 
     return () => {
-      map.off('mousemove', onMouseMove)
-      map.off('mouseout', onMouseLeave)
+      if (rafId !== null) {
+        window.cancelAnimationFrame(rafId)
+      }
+      map.off('mousemove', 'suivi-ban-dept-fill', onLayerMove)
+      map.off('mouseleave', 'suivi-ban-dept-fill', clearDeptHover)
+      map.off('zoomstart', clearDeptHover)
+      map.off('movestart', clearDeptHover)
       setHoveredDept(null)
+      hoveredDeptCodeRef.current = null
+    }
+  }, [selectedTab, suiviBanSelectedDept, suiviBanDeptStats])
+
+  useEffect(() => {
+    if (!ENABLE_HOVER) {
+      setHoveredCommune(null)
+      hoveredCommuneCodeRef.current = null
+      return
+    }
+    if (selectedTab !== 'suivi-ban' || !suiviBanSelectedDept) {
+      setHoveredCommune(null)
+      hoveredCommuneCodeRef.current = null
+      return
+    }
+    const map = mapRef.current?.getMap()
+    if (!map) return
+
+    let rafId: number | null = null
+    let queuedHover: HoveredCommune | null = null
+    const flushHover = () => {
+      setHoveredCommune(queuedHover)
+      rafId = null
+    }
+
+    const queueHoverUpdate = (next: HoveredCommune | null) => {
+      queuedHover = next
+      if (rafId === null) {
+        rafId = window.requestAnimationFrame(flushHover)
+      }
+    }
+
+    const onLayerMove = (e: any) => {
+      if (isMapNavigatingRef.current || map.isMoving() || map.isZooming()) {
+        clearCommuneHover()
+        return
+      }
+      const feature = e.features?.[0]
+      if (!feature?.properties) return
+      const p = feature.properties as any
+      const code = normalizeCode(p.code)
+      hoveredCommuneCodeRef.current = code
+      queueHoverUpdate({
+        code,
+        nom: p.nom || code,
+        statut: p.statut || 'gris',
+        nb_numeros: Number(p.nb_numeros || 0),
+        nb_voies: Number(p.nb_voies || 0),
+        producteur: p.producteur,
+        x: e.point.x,
+        y: e.point.y,
+      })
+    }
+
+    const clearCommuneHover = () => {
+      hoveredCommuneCodeRef.current = null
+      queueHoverUpdate(null)
+    }
+
+    const bindIfReady = () => {
+      if (!map.getLayer('suivi-ban-commune-fill')) return false
+      map.on('mousemove', 'suivi-ban-commune-fill', onLayerMove)
+      map.on('mouseleave', 'suivi-ban-commune-fill', clearCommuneHover)
+      map.on('zoomstart', clearCommuneHover)
+      map.on('movestart', clearCommuneHover)
+      return true
+    }
+
+    if (!bindIfReady()) {
+      map.once('styledata', bindIfReady)
+    }
+
+    return () => {
+      if (rafId !== null) {
+        window.cancelAnimationFrame(rafId)
+      }
+      map.off('mousemove', 'suivi-ban-commune-fill', onLayerMove)
+      map.off('mouseleave', 'suivi-ban-commune-fill', clearCommuneHover)
+      map.off('zoomstart', clearCommuneHover)
+      map.off('movestart', clearCommuneHover)
+      setHoveredCommune(null)
+      hoveredCommuneCodeRef.current = null
     }
   }, [selectedTab, suiviBanSelectedDept])
 
   useEffect(() => {
     if (selectedTab !== 'suivi-ban' || !suiviBanSelectedDept) {
-      setHoveredCommune(null)
+      setSuiviBanCommuneTilesEmpty(false)
       return
     }
+
     const map = mapRef.current?.getMap()
     if (!map) return
 
-    const onMouseMove = (e: any) => {
-      if (!map.getLayer('suivi-ban-commune-fill')) return
-      const features = map.queryRenderedFeatures(e.point, { layers: ['suivi-ban-commune-fill'] })
-      if (features.length > 0) {
-        const p = features[0].properties as any
-        setHoveredCommune({
-          code: p.code,
-          nom: p.nom || p.code,
-          statut: p.statut || 'gris',
-          nb_numeros: Number(p.nb_numeros || 0),
-          nb_voies: Number(p.nb_voies || 0),
-          producteur: p.producteur,
-          x: e.point.x,
-          y: e.point.y,
-        })
-      }
-      else {
-        setHoveredCommune(null)
-      }
+    const evaluateLoadedTiles = () => {
+      if (!map.getSource('suivi-ban-communes')) return
+      if (!map.isSourceLoaded('suivi-ban-communes')) return
+
+      const features = map.querySourceFeatures('suivi-ban-communes', { sourceLayer: 'communes' })
+      setSuiviBanCommuneTilesEmpty(features.length === 0)
     }
 
-    const onMouseLeave = () => setHoveredCommune(null)
-
-    map.on('mousemove', onMouseMove)
-    map.on('mouseout', onMouseLeave)
+    map.on('idle', evaluateLoadedTiles)
+    map.on('moveend', evaluateLoadedTiles)
+    evaluateLoadedTiles()
 
     return () => {
-      map.off('mousemove', onMouseMove)
-      map.off('mouseout', onMouseLeave)
-      setHoveredCommune(null)
+      map.off('idle', evaluateLoadedTiles)
+      map.off('moveend', evaluateLoadedTiles)
     }
-  }, [selectedTab, suiviBanSelectedDept])
+  }, [selectedTab, suiviBanSelectedDept, suiviBanActiveStatuts, suiviBanProducteurFilter])
+
+  const fitToDepartment = useCallback(async (code: string) => {
+    const deptCode = normalizeCode(code)
+    const map = mapRef.current
+    if (!map) return
+
+    try {
+      if (!boundsCacheRef.current.has(deptCode)) {
+        const response = await fetch(`${SUIVI_BAN_API}/departement/${deptCode}/bounds`)
+        if (response.ok) {
+          const rawBounds = await response.json()
+          boundsCacheRef.current.set(deptCode, normalizeBounds(rawBounds))
+        }
+        else {
+          boundsCacheRef.current.set(deptCode, null)
+        }
+      }
+
+      const bounds = boundsCacheRef.current.get(deptCode) ?? null
+      if (bounds) {
+        map.fitBounds(bounds, { padding: 40, duration: 700 })
+        return
+      }
+    }
+    catch (e) {
+      console.warn('Department fit bounds failed:', deptCode, e)
+    }
+
+    const territoire = TERRITOIRES[deptCode]
+    if (territoire) {
+      map.flyTo({ center: [territoire.lon, territoire.lat], zoom: territoire.zoom, duration: 700 })
+    }
+  }, [])
+
+  const handleCommuneClick = useCallback(async (commune: any) => {
+    setSuiviBanSelectedCommune(commune)
+    let enriched = commune
+    let coordinates = getCommuneCoordinates(enriched)
+
+    if (!coordinates && commune?.code) {
+      try {
+        const response = await fetch(`${SUIVI_BAN_API}/commune/${encodeURIComponent(commune.code)}`)
+        if (response.ok) {
+          const full = await response.json()
+          if (full && typeof full === 'object') {
+            enriched = { ...full, ...commune }
+            setSuiviBanSelectedCommune(enriched)
+            coordinates = getCommuneCoordinates(enriched)
+          }
+        }
+      }
+      catch (e) {
+        console.warn('Commune detail load error:', commune?.code, e)
+      }
+    }
+
+    if (coordinates) {
+      mapRef.current?.flyTo({ center: coordinates, zoom: 13, duration: 600 })
+    }
+  }, [mapRef])
 
   const handleMapClick = useCallback((e: any) => {
     if (selectedTab !== 'suivi-ban') return
@@ -260,19 +577,20 @@ export function useSuiviBan({ selectedTab }: UseSuiviBanOptions) {
 
     const communeFeature = features.find((f: any) => f.layer?.id === 'suivi-ban-commune-fill')
     if (communeFeature?.properties) {
-      setSuiviBanSelectedCommune(communeFeature.properties)
+      void handleCommuneClick(communeFeature.properties)
       return
     }
 
     const deptFeature = features.find((f: any) => f.layer?.id === 'suivi-ban-dept-fill')
-    if (deptFeature?.geometry?.coordinates) {
-      const { code, nom } = deptFeature.properties
+    if (deptFeature?.properties) {
+      const code = normalizeCode(deptFeature.properties.code)
+      const nom = deptFeature.properties.nom || code
       const isNewDept = !suiviBanSelectedDept || suiviBanSelectedDept.code !== code
       if (isNewDept) {
+        skipNextFitBoundsRef.current = false
         setSuiviBanSelectedDept({ code, nom })
         setSuiviBanSelectedCommune(null)
-        const bounds = getBoundsFromGeometry(deptFeature.geometry)
-        mapRef.current?.fitBounds(bounds, { padding: 40, duration: 800 })
+        setSuiviBanCommunesMeta([])
       }
       return
     }
@@ -281,20 +599,12 @@ export function useSuiviBan({ selectedTab }: UseSuiviBanOptions) {
       setSuiviBanSelectedCommune(null)
       return
     }
-  }, [selectedTab, suiviBanSelectedDept, mapRef])
-
-  const handleCommuneClick = useCallback((commune: any) => {
-    setSuiviBanSelectedCommune(commune)
-    const coordinates = getCommuneCoordinates(commune)
-    if (coordinates) {
-      mapRef.current?.flyTo({ center: coordinates, zoom: 13, duration: 600 })
-    }
-  }, [mapRef])
+  }, [selectedTab, suiviBanSelectedDept, handleCommuneClick])
 
   const handleSearchSelect = useCallback((commune: any) => {
     if (commune.dept && commune.dept_nom) {
-      setSuiviBanSelectedDept({ code: commune.dept, nom: commune.dept_nom })
-      setSuiviBanCommunesGeoJSON(null)
+      skipNextFitBoundsRef.current = true
+      setSuiviBanSelectedDept({ code: normalizeCode(commune.dept), nom: commune.dept_nom })
     }
     setSuiviBanSelectedCommune(commune)
     const coordinates = getCommuneCoordinates(commune)
@@ -307,15 +617,26 @@ export function useSuiviBan({ selectedTab }: UseSuiviBanOptions) {
     if (!code) return
     const territoire = TERRITOIRES[code]
     if (!territoire) return
+    skipNextFitBoundsRef.current = true
     mapRef.current?.flyTo({ center: [territoire.lon, territoire.lat], zoom: territoire.zoom, duration: 1000 })
     setSuiviBanSelectedDept({ code, nom: territoire.nom })
-    setSuiviBanCommunesGeoJSON(null)
+    setSuiviBanCommunesMeta([])
     setSuiviBanSelectedCommune(null)
   }, [mapRef])
 
+  const handleBackToDepartment = useCallback(() => {
+    setSuiviBanSelectedCommune(null)
+    if (suiviBanSelectedDept) {
+      void fitToDepartment(suiviBanSelectedDept.code)
+    }
+  }, [suiviBanSelectedDept, fitToDepartment])
+
   const handleBack = useCallback(() => {
     setSuiviBanSelectedDept(null)
-    setSuiviBanCommunesGeoJSON(null)
+    setSuiviBanCommunesMeta([])
+    setSuiviBanLoadingCommunes(false)
+    setSuiviBanCommunesError(false)
+    setSuiviBanCommuneTilesEmpty(false)
     setSuiviBanSelectedCommune(null)
     setSuiviBanActiveStatuts(['rouge', 'orange', 'vert', 'gris'])
     setSuiviBanProducteurFilter(null)
@@ -329,10 +650,27 @@ export function useSuiviBan({ selectedTab }: UseSuiviBanOptions) {
   useEffect(() => {
     const map = mapRef.current?.getMap()
     if (!map) return
-    const visibility = selectedTab === 'suivi-ban' ? 'none' : 'visible'
+    const hideForSuiviBan = selectedTab === 'suivi-ban'
+    const balVisibility = hideForSuiviBan ? 'none' : 'visible'
+    const adminVisibility = hideForSuiviBan ? 'none' : 'visible'
+    const adminLayerIds = ['communes', 'departements', 'regions']
     const apply = () => {
       if (map.getLayer('bal-polygon-fill')) {
-        map.setLayoutProperty('bal-polygon-fill', 'visibility', visibility)
+        map.setLayoutProperty('bal-polygon-fill', 'visibility', balVisibility)
+      }
+      adminLayerIds.forEach((layerId) => {
+        if (map.getLayer(layerId)) {
+          map.setLayoutProperty(layerId, 'visibility', adminVisibility)
+        }
+      })
+      if (hideForSuiviBan && map.getLayer('bal-polygon-fill')) {
+        // Place la couche Suivi BAN au-dessus du fond carto pour éviter les artefacts de superposition.
+        if (map.getLayer('suivi-ban-dept-fill')) {
+          map.moveLayer('suivi-ban-dept-fill')
+        }
+        if (map.getLayer('suivi-ban-commune-fill')) {
+          map.moveLayer('suivi-ban-commune-fill')
+        }
       }
     }
     if (map.isStyleLoaded()) apply()
@@ -348,10 +686,12 @@ export function useSuiviBan({ selectedTab }: UseSuiviBanOptions) {
     mapContainerRef,
     interactiveLayerIds,
     balPaintLayer,
-    suiviBanGeoJSON,
+    suiviBanDeptStats,
     suiviBanSelectedDept,
-    suiviBanCommunesGeoJSON,
+    suiviBanCommunesMeta,
     suiviBanLoadingCommunes,
+    suiviBanCommunesError,
+    suiviBanCommuneTilesEmpty,
     suiviBanSelectedCommune,
     setSuiviBanSelectedCommune,
     suiviBanActiveStatuts,
@@ -363,9 +703,10 @@ export function useSuiviBan({ selectedTab }: UseSuiviBanOptions) {
     handleCommuneClick,
     handleSearchSelect,
     handleTerritorySelect,
+    handleBackToDepartment,
     handleBack,
-    hoveredDept,
-    hoveredCommune,
+    hoveredDept: ENABLE_HOVER ? hoveredDept : null,
+    hoveredCommune: ENABLE_HOVER ? hoveredCommune : null,
   }
 }
 

--- a/src/components/Map/FullScreenControl.tsx
+++ b/src/components/Map/FullScreenControl.tsx
@@ -3,12 +3,16 @@ import { ControlPosition, useControl } from 'react-map-gl/maplibre'
 
 type FullScreenControlProps = {
   position?: ControlPosition
+  container?: HTMLElement | null
 }
 
 export function FullScreenControl(props: FullScreenControlProps) {
-  const { position = 'top-right' } = props
+  const { position = 'top-right', container } = props
 
-  useControl(() => new maplibregl.FullscreenControl(), {
+  useControl((context) => {
+    const fallbackContainer = context.map.getContainer().parentElement ?? context.map.getContainer()
+    return new maplibregl.FullscreenControl({ container: container ?? fallbackContainer })
+  }, {
     position,
   })
 


### PR DESCRIPTION
@fufeck
Pour l’histoire de la barre de recherche, pour l’instant : la barre EPCI/Département est utilisée par les onglets « Déploiement BAL » et « Suivi Mes-Adresses », et la barre commune est spécifique à l’onglet « Déploiement idban », qui fonctionne sur une API différente. Les fusionner demanderait de refactoriser la logique de filtrage des trois onglets.

En plus, la carte idban est plus sympa à visualiser en plein écran. Donc on peut la garder comme ça pour le moment, et quand on fera la refacto, on verra ce qu’on en fait. Ça te va ?