### PR TITLE
Affichage credit photo pour article du blog

### DIFF
--- a/src/app/blog/[slug]/page.styled.tsx
+++ b/src/app/blog/[slug]/page.styled.tsx
@@ -50,17 +50,32 @@ export const TextWrapper = styled.div`
 export const ImageWrapper = styled.div`
   display: flex;
   justify-content: center;
-  align-items: center;
-  gap: 1rem;
-  max-height: 25rem;
-  overflow: hidden;
   margin: 2rem -2rem;
-  box-shadow: 0 0 0.3rem rgba(0,0,0,0.1);
+
+  .image-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    max-height: 25rem;
+    overflow: hidden;
+    box-shadow: 0 0 0.3rem rgba(0,0,0,0.1);
+  }
 
   img {
     width: 100%;
     height: auto;
   }
+  figure {
+  margin: 0;
+  width: 100%;
+}
+
+figcaption {
+  font-size: 0.85rem;
+  color: #666;
+  margin-top: 0.5rem;
+  text-align: center;
+}
 
   @media screen and (min-width: ${({ theme }) => theme.breakpoints.md}) {
     margin: 2rem 0 2rem -${ARTICLE_MARGIN_LEFT};

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -30,6 +30,7 @@ export default async function BlogPost({ params }: { params: { slug: string } })
     title,
     tags,
     feature_image: featureImage,
+    feature_image_caption: featureImageCaption,
     authors,
     published_at: publishedAt,
     reading_time: readingTime,
@@ -90,7 +91,15 @@ export default async function BlogPost({ params }: { params: { slug: string } })
 
             {featureImage && (
               <ImageWrapper>
-                <ResponsiveImage src={featureImage} alt={title} />
+                <figure>
+                  <ResponsiveImage src={featureImage} alt={title} />
+
+                  {featureImageCaption && (
+                    <figcaption
+                      dangerouslySetInnerHTML={{ __html: featureImageCaption }}
+                    />
+                  )}
+                </figure>
               </ImageWrapper>
             )}
 


### PR DESCRIPTION
Le crédit photo sous la photo n'est pas repris sur l'article du blog
Fix: #2080

Pour tester et voir le crédit photo sous l'image, voici 2 urls :
https://adresse-data-gouv-fr-pr2450.osc-fr1.scalingo.io/blog/lutilisation-de-la-ban-par-ccr
https://adresse-data-gouv-fr-pr2450.osc-fr1.scalingo.io/blog/feminiser-et-decoloniser-les-noms-de-voies
