### PR TITLE
Zoom image issue2271

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -111,7 +111,7 @@ export default async function BlogPost(props: { params: Promise<{ slug: string }
               </div>
             </AuthorWrapper>
 
-            <HtmlViewer html={contentHtml} />
+            <HtmlViewer html={contentHtml} enableImageZoom />
           </article>
           <aside>
             <AsideContent />

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -42,21 +42,7 @@ export default async function BlogPost(props: { params: Promise<{ slug: string }
   const excerptRegex = new RegExp(excerpt.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&'), 'i')
   const excerptMatch = contentHtml.match(excerptRegex)
   const excerptIndex = excerptMatch?.index || 0
-  const sanitizedCaption =
-    typeof featureImageCaption === 'string'
-      ? DOMPurify.sanitize(featureImageCaption, {
-          ALLOWED_TAGS: [
-            'b',
-            'i',
-            'em',
-            'strong',
-            'a',
-            'br',
-          ],
-          ALLOWED_ATTR: ['href'],
-        })
-      : ''
-      
+
   return (
     <>
       <Breadcrumb
@@ -109,7 +95,7 @@ export default async function BlogPost(props: { params: Promise<{ slug: string }
             {featureImage && (
               <ImageWrapper>
                 <figure>
-                  <ResponsiveImage src={featureImage} alt={title} />
+                  <ResponsiveImage src={featureImage} alt={title} zoomable />
                   {typeof featureImageCaption === "string" && (
                     <figcaption>
                      {parseHtmlReact(DOMPurify.sanitize(featureImageCaption))}

--- a/src/app/layout-client.tsx
+++ b/src/app/layout-client.tsx
@@ -16,6 +16,7 @@ import { BALWidgetProvider } from '@/contexts/BALWidget.context'
 import StyledComponentsRegistry from '@/providers/StyledComponentsRegistry'
 import theme from '@/theme'
 import { defaultColorScheme } from '@/theme/defaultColorScheme'
+import { ImageLightboxProvider } from '@/components/ImageLightbox'
 import GlobalStyle from './global.styles'
 import { StyledLayout, PageWrapper } from './layout.styles'
 import { AlerteRecord } from '@/lib/api-grist'
@@ -67,25 +68,27 @@ export default function LayoutClient({ children, lang, alertes }: LayoutClientPr
         <LayoutProvider>
           <ThemeProvider theme={theme}>
             <BALWidgetProvider>
-              <GlobalStyle />
-              <StyledLayout>
-                <Header notices={dataNotices} />
-                <PageWrapper>{children}</PageWrapper>
-                <Footer />
-                <ToastContainer
-                  position="bottom-right"
-                  autoClose={5000}
-                  hideProgressBar
-                  newestOnTop={false}
-                  closeOnClick={false}
-                  rtl={false}
-                  pauseOnFocusLoss
-                  draggable
-                  pauseOnHover
-                  theme="dark"
-                  transition={Slide}
-                />
-              </StyledLayout>
+              <ImageLightboxProvider>
+                <GlobalStyle />
+                <StyledLayout>
+                  <Header notices={dataNotices} />
+                  <PageWrapper>{children}</PageWrapper>
+                  <Footer />
+                  <ToastContainer
+                    position="bottom-right"
+                    autoClose={5000}
+                    hideProgressBar
+                    newestOnTop={false}
+                    closeOnClick={false}
+                    rtl={false}
+                    pauseOnFocusLoss
+                    draggable
+                    pauseOnHover
+                    theme="dark"
+                    transition={Slide}
+                  />
+                </StyledLayout>
+              </ImageLightboxProvider>
             </BALWidgetProvider>
           </ThemeProvider>
         </LayoutProvider>

--- a/src/components/BlogCard/BlogCard.tsx
+++ b/src/components/BlogCard/BlogCard.tsx
@@ -1,5 +1,6 @@
 import Card from '@codegouvfr/react-dsfr/Card'
 import Tag from '@codegouvfr/react-dsfr/Tag'
+import ResponsiveImage from '@/components/ResponsiveImage'
 
 export interface PostItem {
   title: string

--- a/src/components/HtmlViewer/HtmlViewer.styles.tsx
+++ b/src/components/HtmlViewer/HtmlViewer.styles.tsx
@@ -58,11 +58,14 @@ export const TextWrapper = styled.div`
       box-shadow: 0 0 1rem -0.7rem;
     }
 
-    img.html-viewer__zoomable-image {
+    .html-viewer__zoomable-image {
+      border: none;
+      background: transparent;
+      padding: 0;
       cursor: zoom-in;
     }
 
-    img.html-viewer__zoomable-image:focus-visible {
+    .html-viewer__zoomable-image:focus-visible {
       outline: 2px solid var(--border-action-high-blue-france);
       outline-offset: 4px;
     }

--- a/src/components/HtmlViewer/HtmlViewer.styles.tsx
+++ b/src/components/HtmlViewer/HtmlViewer.styles.tsx
@@ -58,6 +58,15 @@ export const TextWrapper = styled.div`
       box-shadow: 0 0 1rem -0.7rem;
     }
 
+    img.html-viewer__zoomable-image {
+      cursor: zoom-in;
+    }
+
+    img.html-viewer__zoomable-image:focus-visible {
+      outline: 2px solid var(--border-action-high-blue-france);
+      outline-offset: 4px;
+    }
+
     figure {
       display: flex;
       flex-direction: column;

--- a/src/components/HtmlViewer/HtmlViewer.tsx
+++ b/src/components/HtmlViewer/HtmlViewer.tsx
@@ -5,7 +5,13 @@ import { useImageLightbox } from '@/components/ImageLightbox'
 
 import { TextWrapper } from './HtmlViewer.styles'
 
-export default function HtmlViewer({ html, isStyled = true }: { html: string, isStyled?: boolean }) {
+interface HtmlViewerProps {
+  html: string
+  isStyled?: boolean
+  enableImageZoom?: boolean
+}
+
+export default function HtmlViewer({ html, isStyled = true, enableImageZoom = false }: HtmlViewerProps) {
   const wrapperElement = useRef(null)
   const { openImage } = useImageLightbox()
 
@@ -15,6 +21,10 @@ export default function HtmlViewer({ html, isStyled = true }: { html: string, is
     element?.querySelectorAll('video').forEach((video: HTMLVideoElement) => {
       video.controls = true
     })
+
+    if (!enableImageZoom) {
+      return
+    }
 
     const imageElements = Array.from(element?.querySelectorAll('img') || []) as HTMLImageElement[]
     const cleanups: Array<() => void> = []
@@ -52,7 +62,7 @@ export default function HtmlViewer({ html, isStyled = true }: { html: string, is
     return () => {
       cleanups.forEach((cleanup) => cleanup())
     }
-  }, [html, openImage])
+  }, [html, openImage, enableImageZoom])
 
   return html && (
     isStyled

--- a/src/components/HtmlViewer/HtmlViewer.tsx
+++ b/src/components/HtmlViewer/HtmlViewer.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useEffect, useRef } from 'react'
-import { useImageLightbox } from '@/components/ImageLightbox'
+import parse, { domToReact, Element, HTMLReactParserOptions } from 'html-react-parser'
+import ZoomableImage from '@/components/ImageLightbox/ZoomableImage'
 
 import { TextWrapper } from './HtmlViewer.styles'
 
@@ -12,61 +12,49 @@ interface HtmlViewerProps {
 }
 
 export default function HtmlViewer({ html, isStyled = true, enableImageZoom = false }: HtmlViewerProps) {
-  const wrapperElement = useRef(null)
-  const { openImage } = useImageLightbox()
-
-  useEffect(() => {
-    const element = wrapperElement.current as unknown as HTMLElement | null
-
-    element?.querySelectorAll('video').forEach((video: HTMLVideoElement) => {
-      video.controls = true
-    })
-
-    if (!enableImageZoom) {
-      return
-    }
-
-    const imageElements = Array.from(element?.querySelectorAll('img') || []) as HTMLImageElement[]
-    const cleanups: Array<() => void> = []
-
-    imageElements.forEach((img) => {
-      if (!img.src || img.closest('a')) {
+  const parserOptions: HTMLReactParserOptions = {
+    replace: (node) => {
+      if (!(node instanceof Element)) {
         return
       }
 
-      img.classList.add('html-viewer__zoomable-image')
-      img.setAttribute('role', 'button')
-      img.setAttribute('tabindex', '0')
-      img.setAttribute('aria-label', `Agrandir l'image${img.alt ? `: ${img.alt}` : ''}`)
-
-      const onOpen = () => {
-        openImage({ src: img.currentSrc || img.src, alt: img.alt || 'Image de contenu' })
+      if (node.name === 'video') {
+        return (
+          <video controls>
+            {domToReact(node.children as never, parserOptions)}
+          </video>
+        )
       }
 
-      const onKeyDown = (event: KeyboardEvent) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault()
-          onOpen()
-        }
+      if (!enableImageZoom || node.name !== 'img' || !node.attribs?.src) {
+        return
       }
 
-      img.addEventListener('click', onOpen)
-      img.addEventListener('keydown', onKeyDown)
+      if (node.parent?.type === 'tag' && node.parent.name === 'a') {
+        return
+      }
 
-      cleanups.push(() => {
-        img.removeEventListener('click', onOpen)
-        img.removeEventListener('keydown', onKeyDown)
-      })
-    })
+      const src = node.attribs.src
+      const alt = node.attribs.alt || 'Image de contenu'
 
-    return () => {
-      cleanups.forEach((cleanup) => cleanup())
+      return (
+        <ZoomableImage
+          src={src}
+          alt={alt}
+          width={0}
+          height={0}
+          sizes="100vw"
+          style={{ width: '100%', height: 'auto' }}
+          buttonClassName="html-viewer__zoomable-image"
+          buttonLabel="Agrandir l'image"
+        />
+      )
     }
-  }, [html, openImage, enableImageZoom])
+  }
 
   return html && (
     isStyled
-      ? <TextWrapper ref={wrapperElement} dangerouslySetInnerHTML={{ __html: html }} />
-      : <div ref={wrapperElement} dangerouslySetInnerHTML={{ __html: html }} />
+      ? <TextWrapper>{parse(html, parserOptions)}</TextWrapper>
+      : <div>{parse(html, parserOptions)}</div>
   )
 }

--- a/src/components/HtmlViewer/HtmlViewer.tsx
+++ b/src/components/HtmlViewer/HtmlViewer.tsx
@@ -1,17 +1,58 @@
 'use client'
 
 import { useEffect, useRef } from 'react'
+import { useImageLightbox } from '@/components/ImageLightbox'
 
 import { TextWrapper } from './HtmlViewer.styles'
 
 export default function HtmlViewer({ html, isStyled = true }: { html: string, isStyled?: boolean }) {
   const wrapperElement = useRef(null)
+  const { openImage } = useImageLightbox()
 
   useEffect(() => {
-    (wrapperElement.current as unknown as HTMLElement)?.querySelectorAll('video').forEach((video: HTMLVideoElement) => {
+    const element = wrapperElement.current as unknown as HTMLElement | null
+
+    element?.querySelectorAll('video').forEach((video: HTMLVideoElement) => {
       video.controls = true
     })
-  }, [])
+
+    const imageElements = Array.from(element?.querySelectorAll('img') || []) as HTMLImageElement[]
+    const cleanups: Array<() => void> = []
+
+    imageElements.forEach((img) => {
+      if (!img.src || img.closest('a')) {
+        return
+      }
+
+      img.classList.add('html-viewer__zoomable-image')
+      img.setAttribute('role', 'button')
+      img.setAttribute('tabindex', '0')
+      img.setAttribute('aria-label', `Agrandir l'image${img.alt ? `: ${img.alt}` : ''}`)
+
+      const onOpen = () => {
+        openImage({ src: img.currentSrc || img.src, alt: img.alt || 'Image de contenu' })
+      }
+
+      const onKeyDown = (event: KeyboardEvent) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault()
+          onOpen()
+        }
+      }
+
+      img.addEventListener('click', onOpen)
+      img.addEventListener('keydown', onKeyDown)
+
+      cleanups.push(() => {
+        img.removeEventListener('click', onOpen)
+        img.removeEventListener('keydown', onKeyDown)
+      })
+    })
+
+    return () => {
+      cleanups.forEach((cleanup) => cleanup())
+    }
+  }, [html, openImage])
 
   return html && (
     isStyled

--- a/src/components/ImageLightbox/ImageLightboxProvider.tsx
+++ b/src/components/ImageLightbox/ImageLightboxProvider.tsx
@@ -56,7 +56,7 @@ const LightboxModalStyle = createGlobalStyle`
   }
 
   .image-lightbox-modal .fr-modal__body {
-    width: calc(100vw - 1rem);
+    width: auto;
     max-width: calc(100vw - 1rem);
     max-height: calc(100vh - 1rem);
     padding: 0;

--- a/src/components/ImageLightbox/ImageLightboxProvider.tsx
+++ b/src/components/ImageLightbox/ImageLightboxProvider.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react'
+import Image from 'next/image'
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react'
 import { createModal } from '@codegouvfr/react-dsfr/Modal'
 import { useIsModalOpen } from '@codegouvfr/react-dsfr/Modal/useIsModalOpen'
 import { createGlobalStyle } from 'styled-components'
@@ -14,22 +15,39 @@ interface ImageLightboxContextValue {
   openImage: (image: LightboxImage) => void
 }
 
-const ImageLightboxContext = createContext<ImageLightboxContextValue | null>(null)
-
 interface ImageLightboxProviderProps {
   children: ReactNode
 }
+
+interface ImageDimensions {
+  width: number
+  height: number
+}
+
+interface ViewportSize {
+  width: number
+  height: number
+}
+
+const ImageLightboxContext = createContext<ImageLightboxContextValue | null>(null)
 
 const modal = createModal({
   id: 'image-lightbox-modal',
   isOpenedByDefault: false,
 })
 
+const MAX_LIGHTBOX_UPSCALE = 1.75
+const MOBILE_MAX_LIGHTBOX_UPSCALE = 1.35
+const FALLBACK_VIEWPORT_WIDTH = 1280
+const FALLBACK_VIEWPORT_HEIGHT = 900
+const LIGHTBOX_FRAME_PADDING_X = 16
+const LIGHTBOX_FRAME_PADDING_Y = 24
+
 const LightboxModalStyle = createGlobalStyle`
   .image-lightbox-modal .fr-container,
   .image-lightbox-modal .fr-grid-row > div {
     width: auto;
-    max-width: calc(100vw - 1rem);
+    max-width: 100vw;
   }
 
   .image-lightbox-modal .fr-grid-row {
@@ -38,31 +56,36 @@ const LightboxModalStyle = createGlobalStyle`
   }
 
   .image-lightbox-modal .fr-modal__body {
-    width: auto;
+    width: calc(100vw - 1rem);
     max-width: calc(100vw - 1rem);
     max-height: calc(100vh - 1rem);
     padding: 0;
+    overflow: hidden;
   }
 
   .image-lightbox-modal .fr-modal__header {
     position: absolute;
-    top: 0.75rem;
-    right: 0.75rem;
+    top: 0.5rem;
+    right: 0.5rem;
     z-index: 2;
     padding: 0;
   }
 
   .image-lightbox-modal .fr-btn--close {
     margin-left: auto;
+    background-color: var(--background-default-grey-hover);
+    border-radius: 999px;
   }
 
   .image-lightbox-modal .fr-modal__content {
-    padding: 3.5rem 1rem 1rem;
+    padding: 3.25rem 1rem 1.75rem;
     display: flex;
     align-items: center;
     justify-content: center;
-    width: auto;
-    max-width: calc(100vw - 1rem);
+    width: 100%;
+    max-height: calc(100vh - 1rem);
+    overflow: hidden;
+    box-sizing: border-box;
   }
 
   .image-lightbox-modal .fr-modal__title {
@@ -78,49 +101,189 @@ const LightboxModalStyle = createGlobalStyle`
   }
 
   @media (min-width: 48rem) {
+    .image-lightbox-modal .fr-modal__header {
+      top: 0.75rem;
+      right: 0.75rem;
+    }
+
     .image-lightbox-modal .fr-modal__content {
       padding: 4rem 2rem 2rem;
     }
   }
 `
 
+const LightboxImage = createGlobalStyle`
+  .image-lightbox-modal__image-wrapper {
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin: 0 auto;
+  }
+
+  .image-lightbox-modal__image-frame {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--background-default-grey);
+    border-radius: 0.5rem;
+    padding: 0.5rem 0.5rem 1rem;
+    box-sizing: border-box;
+    max-width: 100%;
+    max-height: 100%;
+  }
+
+  .image-lightbox-modal__image {
+    width: 100%;
+    height: 100%;
+    display: block;
+    object-fit: contain;
+  }
+`
+
 export default function ImageLightboxProvider({ children }: ImageLightboxProviderProps) {
   const [activeImage, setActiveImage] = useState<LightboxImage | null>(null)
+  const [activeImageDimensions, setActiveImageDimensions] = useState<ImageDimensions | null>(null)
+  const [viewportSize, setViewportSize] = useState<ViewportSize>({
+    width: FALLBACK_VIEWPORT_WIDTH,
+    height: FALLBACK_VIEWPORT_HEIGHT,
+  })
+  const activeImageAlt = activeImage?.alt?.trim() || 'Image agrandie'
+
+  useEffect(() => {
+    const handleViewportResize = () => {
+      setViewportSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      })
+    }
+
+    handleViewportResize()
+    window.addEventListener('resize', handleViewportResize)
+
+    return () => {
+      window.removeEventListener('resize', handleViewportResize)
+    }
+  }, [])
 
   const openImage = useCallback((image: LightboxImage) => {
     setActiveImage(image)
+    setActiveImageDimensions(null)
     modal.open()
   }, [])
 
   useIsModalOpen(modal, {
-    onConceal: () => setActiveImage(null),
+    onConceal: () => {
+      setActiveImage(null)
+      setActiveImageDimensions(null)
+    },
   })
+
+  const renderedImageSize = useMemo(() => {
+    const isMobileViewport = viewportSize.width < 768
+    const horizontalChrome = isMobileViewport ? 24 : 96
+    const verticalChrome = isMobileViewport ? 164 : 220
+
+    const maxFrameWidth = Math.max(viewportSize.width - horizontalChrome, 220)
+    const maxFrameHeight = Math.max(viewportSize.height - verticalChrome, 180)
+    const maxImageWidth = Math.max(maxFrameWidth - LIGHTBOX_FRAME_PADDING_X, 180)
+    const maxImageHeight = Math.max(maxFrameHeight - LIGHTBOX_FRAME_PADDING_Y, 140)
+
+    if (!activeImageDimensions) {
+      const defaultRatio = 16 / 9
+
+      if (maxImageWidth / maxImageHeight > defaultRatio) {
+        const imageHeight = Math.round(maxImageHeight)
+        const imageWidth = Math.round(maxImageHeight * defaultRatio)
+
+        return {
+          imageWidth,
+          imageHeight,
+          frameWidth: imageWidth + LIGHTBOX_FRAME_PADDING_X,
+          frameHeight: imageHeight + LIGHTBOX_FRAME_PADDING_Y,
+        }
+      }
+
+      const imageWidth = Math.round(maxImageWidth)
+      const imageHeight = Math.round(maxImageWidth / defaultRatio)
+
+      return {
+        imageWidth,
+        imageHeight,
+        frameWidth: imageWidth + LIGHTBOX_FRAME_PADDING_X,
+        frameHeight: imageHeight + LIGHTBOX_FRAME_PADDING_Y,
+      }
+    }
+
+    const isVeryTallImage = activeImageDimensions.height / activeImageDimensions.width > 1.35
+    const isVeryLargeImage = activeImageDimensions.height > 1600
+    const verticalSafetyFactor = isVeryTallImage || isVeryLargeImage ? 0.88 : 0.95
+    const safeImageHeight = Math.round(maxImageHeight * verticalSafetyFactor)
+
+    const fitScale = Math.min(
+      maxImageWidth / activeImageDimensions.width,
+      safeImageHeight / activeImageDimensions.height,
+    )
+
+    const maxUpscale = isMobileViewport ? MOBILE_MAX_LIGHTBOX_UPSCALE : MAX_LIGHTBOX_UPSCALE
+    const scale = Math.min(fitScale, maxUpscale)
+
+    const imageWidth = Math.max(1, Math.round(activeImageDimensions.width * scale))
+    const imageHeight = Math.max(1, Math.round(activeImageDimensions.height * scale))
+
+    return {
+      imageWidth,
+      imageHeight,
+      frameWidth: imageWidth + LIGHTBOX_FRAME_PADDING_X,
+      frameHeight: imageHeight + LIGHTBOX_FRAME_PADDING_Y,
+    }
+  }, [activeImageDimensions, viewportSize.height, viewportSize.width])
 
   const value = useMemo(() => ({ openImage }), [openImage])
 
   return (
     <ImageLightboxContext.Provider value={value}>
       <LightboxModalStyle />
+      <LightboxImage />
       {children}
       <modal.Component
         className="image-lightbox-modal"
         size="large"
-        title={activeImage?.alt || 'Agrandissement de l\'image'}
+        title={`Agrandissement de l'image : ${activeImageAlt}`}
       >
         {activeImage && (
-          <img
-            src={activeImage.src}
-            alt={activeImage.alt}
-            style={{
-              maxWidth: 'calc(100vw - 3rem)',
-              maxHeight: 'calc(100vh - 3rem)',
-              width: 'auto',
-              height: 'auto',
-              objectFit: 'contain',
-              display: 'block',
-              margin: '0 auto',
-            }}
-          />
+          <div className="image-lightbox-modal__image-wrapper">
+            <div
+              className="image-lightbox-modal__image-frame"
+              style={{ width: `${renderedImageSize.frameWidth}px`, height: `${renderedImageSize.frameHeight}px` }}
+            >
+              <Image
+                src={activeImage.src}
+                alt={activeImageAlt}
+                width={activeImageDimensions?.width || renderedImageSize.imageWidth}
+                height={activeImageDimensions?.height || renderedImageSize.imageHeight}
+                sizes="100vw"
+                priority
+                className="image-lightbox-modal__image"
+                onLoadingComplete={(imageElement) => {
+                  const width = imageElement.naturalWidth
+                  const height = imageElement.naturalHeight
+
+                  if (!width || !height) {
+                    return
+                  }
+
+                  setActiveImageDimensions((previousDimensions) => {
+                    if (previousDimensions?.width === width && previousDimensions?.height === height) {
+                      return previousDimensions
+                    }
+
+                    return { width, height }
+                  })
+                }}
+              />
+            </div>
+          </div>
         )}
       </modal.Component>
     </ImageLightboxContext.Provider>

--- a/src/components/ImageLightbox/ImageLightboxProvider.tsx
+++ b/src/components/ImageLightbox/ImageLightboxProvider.tsx
@@ -1,0 +1,138 @@
+'use client'
+
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react'
+import { createModal } from '@codegouvfr/react-dsfr/Modal'
+import { useIsModalOpen } from '@codegouvfr/react-dsfr/Modal/useIsModalOpen'
+import { createGlobalStyle } from 'styled-components'
+
+interface LightboxImage {
+  src: string
+  alt: string
+}
+
+interface ImageLightboxContextValue {
+  openImage: (image: LightboxImage) => void
+}
+
+const ImageLightboxContext = createContext<ImageLightboxContextValue | null>(null)
+
+interface ImageLightboxProviderProps {
+  children: ReactNode
+}
+
+const modal = createModal({
+  id: 'image-lightbox-modal',
+  isOpenedByDefault: false,
+})
+
+const LightboxModalStyle = createGlobalStyle`
+  .image-lightbox-modal .fr-container,
+  .image-lightbox-modal .fr-grid-row > div {
+    width: auto;
+    max-width: calc(100vw - 1rem);
+  }
+
+  .image-lightbox-modal .fr-grid-row {
+    display: flex;
+    justify-content: center;
+  }
+
+  .image-lightbox-modal .fr-modal__body {
+    width: auto;
+    max-width: calc(100vw - 1rem);
+    max-height: calc(100vh - 1rem);
+    padding: 0;
+  }
+
+  .image-lightbox-modal .fr-modal__header {
+    position: absolute;
+    top: 0.75rem;
+    right: 0.75rem;
+    z-index: 2;
+    padding: 0;
+  }
+
+  .image-lightbox-modal .fr-btn--close {
+    margin-left: auto;
+  }
+
+  .image-lightbox-modal .fr-modal__content {
+    padding: 3.5rem 1rem 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: auto;
+    max-width: calc(100vw - 1rem);
+  }
+
+  .image-lightbox-modal .fr-modal__title {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  @media (min-width: 48rem) {
+    .image-lightbox-modal .fr-modal__content {
+      padding: 4rem 2rem 2rem;
+    }
+  }
+`
+
+export default function ImageLightboxProvider({ children }: ImageLightboxProviderProps) {
+  const [activeImage, setActiveImage] = useState<LightboxImage | null>(null)
+
+  const openImage = useCallback((image: LightboxImage) => {
+    setActiveImage(image)
+    modal.open()
+  }, [])
+
+  useIsModalOpen(modal, {
+    onConceal: () => setActiveImage(null),
+  })
+
+  const value = useMemo(() => ({ openImage }), [openImage])
+
+  return (
+    <ImageLightboxContext.Provider value={value}>
+      <LightboxModalStyle />
+      {children}
+      <modal.Component
+        className="image-lightbox-modal"
+        size="large"
+        title={activeImage?.alt || 'Agrandissement de l\'image'}
+      >
+        {activeImage && (
+          <img
+            src={activeImage.src}
+            alt={activeImage.alt}
+            style={{
+              maxWidth: 'calc(100vw - 3rem)',
+              maxHeight: 'calc(100vh - 3rem)',
+              width: 'auto',
+              height: 'auto',
+              objectFit: 'contain',
+              display: 'block',
+              margin: '0 auto',
+            }}
+          />
+        )}
+      </modal.Component>
+    </ImageLightboxContext.Provider>
+  )
+}
+
+export function useImageLightbox() {
+  const context = useContext(ImageLightboxContext)
+
+  if (!context) {
+    throw new Error('useImageLightbox must be used within ImageLightboxProvider')
+  }
+
+  return context
+}

--- a/src/components/ImageLightbox/ZoomableImage.module.css
+++ b/src/components/ImageLightbox/ZoomableImage.module.css
@@ -1,0 +1,53 @@
+.zoomableButton {
+  border: none;
+  padding: 0;
+  margin: 0;
+  width: 100%;
+  background: transparent;
+  cursor: zoom-in;
+  display: block;
+  position: relative;
+}
+
+.indicator {
+  position: absolute;
+  right: 0.75rem;
+  bottom: 0.75rem;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: var(--background-default-grey);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transform: translateY(4px);
+  transition: opacity 160ms ease, transform 160ms ease;
+  pointer-events: none;
+}
+
+.zoomableButton:hover .indicator,
+.zoomableButton:focus-visible .indicator {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (hover: none) {
+  .indicator {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/components/ImageLightbox/ZoomableImage.tsx
+++ b/src/components/ImageLightbox/ZoomableImage.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import Image, { type ImageProps } from 'next/image'
+import { useImageLightbox } from './ImageLightboxProvider'
+import styles from './ZoomableImage.module.css'
+
+interface ZoomableImageProps extends ImageProps {
+  buttonLabel?: string
+  buttonClassName?: string
+  buttonStyle?: React.CSSProperties
+}
+
+function resolveImageSource(src: ImageProps['src']) {
+  if (typeof src === 'string') {
+    return src
+  }
+
+  if ('src' in src) {
+    return src.src
+  }
+
+  return src.default.src
+}
+
+export default function ZoomableImage({
+  alt,
+  src,
+  buttonLabel = 'Agrandir l\'image',
+  buttonClassName,
+  buttonStyle,
+  ...imageProps
+}: ZoomableImageProps) {
+  const { openImage } = useImageLightbox()
+
+  return (
+    <button
+      type="button"
+      onClick={() => openImage({ src: resolveImageSource(src), alt })}
+      className={[styles.zoomableButton, buttonClassName].filter(Boolean).join(' ')}
+      style={buttonStyle}
+      aria-label={`${buttonLabel}: ${alt}`}
+    >
+      <Image {...imageProps} src={src} alt={alt} />
+      <span className={styles.indicator} aria-hidden="true">
+        <span className="fr-icon-search-line" aria-hidden="true" />
+      </span>
+      <span className={styles.srOnly}>{buttonLabel}</span>
+    </button>
+  )
+}

--- a/src/components/ImageLightbox/ZoomableImage.tsx
+++ b/src/components/ImageLightbox/ZoomableImage.tsx
@@ -42,7 +42,7 @@ export default function ZoomableImage({
     >
       <Image {...imageProps} src={src} alt={alt} />
       <span className={styles.indicator} aria-hidden="true">
-        <span className="fr-icon-search-line" aria-hidden="true" />
+        <span className="fr-icon fr-icon-search-line" aria-hidden="true" />
       </span>
       <span className={styles.srOnly}>{buttonLabel}</span>
     </button>

--- a/src/components/ImageLightbox/index.ts
+++ b/src/components/ImageLightbox/index.ts
@@ -1,0 +1,2 @@
+export { default as ImageLightboxProvider, useImageLightbox } from './ImageLightboxProvider'
+export { default as ZoomableImage } from './ZoomableImage'

--- a/src/components/ResponsiveImage/index.tsx
+++ b/src/components/ResponsiveImage/index.tsx
@@ -1,13 +1,29 @@
 import Image from 'next/image'
+import { ZoomableImage } from '@/components/ImageLightbox'
 
 export interface ResponsiveImageProps {
   src: string
   alt: string
   style?: React.CSSProperties
   className?: string
+  zoomable?: boolean
 }
 
-export default function ResponsiveImage({ src, alt, style, className }: ResponsiveImageProps) {
+export default function ResponsiveImage({ src, alt, style, className, zoomable = false }: ResponsiveImageProps) {
+  if (zoomable) {
+    return (
+      <ZoomableImage
+        src={src}
+        alt={alt}
+        width={0}
+        height={0}
+        className={className}
+        sizes="100vw"
+        style={{ width: '100%', height: 'auto', ...style }}
+      />
+    )
+  }
+
   return (
     <Image
       src={src}


### PR DESCRIPTION
Création d'un composant pour ajouter la possibilité de voir une image plus grande sous forme de popin en cliquant sur une image. l'utilisateur pourra agrandir encore plus cette image avec le zoom navigateur
Cette fonctionnalité a été mis en place sur le blog mais peut être utilisé sur toutes les pages du site pour agrandir une image avec un bouton "Fermer" 

Fix: #2271 

<img width="1115" height="737" alt="Capture d’écran du 2026-05-20 10-20-06" src="https://github.com/user-attachments/assets/c3d062f9-37c0-4e61-9903-d6693977b07b" />
