### PR TITLE
Gestion cache sur multiples pages

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -62,7 +62,7 @@ function BlogView() {
   useEffect(() => {
     getPosts({
       limit: nbHighlightedPosts,
-    }).then((data) => {
+    }, { cache: 'no-store' }).then((data) => {
       setHighlightedPosts(data.posts)
     })
   }, [])
@@ -75,8 +75,8 @@ function BlogView() {
         page,
         limit: nbPost,
         tags: tags.size ? [...tags].join(',') : undefined,
-      }),
-      getTags(),
+      }, { cache: 'no-store' }),
+      getTags({ cache: 'no-store' }),
     ])
       .then(([postsData, tagsData]) => {
         if (!isCurrent) {

--- a/src/lib/api-bal-admin.ts
+++ b/src/lib/api-bal-admin.ts
@@ -39,7 +39,7 @@ export async function getPartenairesDeLaCharte(queryObject: PartenairesDeLaChart
   url.searchParams.append('limit', limit.toString())
   addSearchParams(url, queryObject)
 
-  return customFetch(url, { cache: 'force-cache' })
+  return customFetch(url, { next: { revalidate: 1800 } })
 }
 
 export async function getPartenairesDeLaCharteServices(queryObject: PartenairesDeLaCharteQuery): Promise<Record<string, number>> {

--- a/src/lib/api-bal-admin.ts
+++ b/src/lib/api-bal-admin.ts
@@ -87,7 +87,10 @@ export async function sendReview(partenaireId: string, review: ReviewFormType) {
 
 export async function getBalEvents(): Promise<EventType[]> {
   try {
-    const response = await fetch(`${env('NEXT_PUBLIC_BAL_ADMIN_API_URL')}/events`, { cache: 'force-cache' })
+    const response = await fetch(
+      `${env('NEXT_PUBLIC_BAL_ADMIN_API_URL')}/events`,
+      { cache: 'no-store' }
+    )
     if (!response.ok) {
       void response.body?.cancel().catch(() => {})
       throw new Error('Error while fetching bal events')

--- a/src/lib/api-ban.ts
+++ b/src/lib/api-ban.ts
@@ -20,7 +20,7 @@ export function getBanItem(idBanItem: string, signal?: AbortSignal): Promise<BAN
 }
 
 export function getStats(): Promise<BANStats> {
-  return customFetch(`${API_BAN_SEARCH_URL}/ban/stats`, { cache: 'force-cache' })
+  return customFetch(`${API_BAN_SEARCH_URL}/ban/stats`, { next: { revalidate: 3600 } })
 }
 
 export function getCommune(codeCommune: string, signal?: AbortSignal): Promise<BANCommune> {

--- a/src/lib/api-data-gouv.ts
+++ b/src/lib/api-data-gouv.ts
@@ -6,5 +6,5 @@ if (!env('NEXT_PUBLIC_DATAGOUV_URL')) {
 }
 
 export function getDataset(datasetId: string) {
-  return customFetch(`${env('NEXT_PUBLIC_DATAGOUV_URL')}/datasets/${datasetId}`, { cache: 'force-cache' })
+  return customFetch(`${env('NEXT_PUBLIC_DATAGOUV_URL')}/datasets/${datasetId}`, { cache: 'no-store' })
 }

--- a/src/lib/api-depot.tsx
+++ b/src/lib/api-depot.tsx
@@ -71,7 +71,7 @@ export async function getCurrentRevisionFile(codeCommune: string): Promise<any> 
 }
 
 export async function getRevisions(codeCommune: string): Promise<Revision[]> {
-  const revisions = await customFetch(`${env('NEXT_PUBLIC_API_DEPOT_URL')}/communes/${codeCommune}/revisions`, { cache: 'force-cache' })
+  const revisions = await customFetch(`${env('NEXT_PUBLIC_API_DEPOT_URL')}/communes/${codeCommune}/revisions`, { cache: 'no-store' })
 
   return revisions.sort((a: Revision, b: Revision) => {
     return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()

--- a/src/lib/api-etablissement-public.ts
+++ b/src/lib/api-etablissement-public.ts
@@ -11,7 +11,7 @@ export async function getMairiePageURL(codeCommune: string) {
   const query = `select=nom,url_service_public&where=code_insee_commune="${codeCommune}" and pivot LIKE "mairie"&limit=-1`
   const url = `${env('NEXT_PUBLIC_API_ETABLISSEMENTS_PUBLIC')}/${route}?${query}`
 
-  const response: { results: APIEtablissementPublicMairie[] } = await customFetch(url, { cache: 'force-cache' })
+  const response: { results: APIEtablissementPublicMairie[] } = await customFetch(url, { next: { revalidate: 1800 } })
   if (!response?.results || response.results.length === 0) {
     return null
   }

--- a/src/lib/api-geo.ts
+++ b/src/lib/api-geo.ts
@@ -33,7 +33,7 @@ export function getEPCI(code: string, fields?: string[]): Promise<EPCI> {
     url.searchParams.append('fields', fields.toString())
   }
 
-  return customFetch(url, { cache: 'force-cache' })
+  return customFetch(url, { next: { revalidate: 1800 } })
 }
 
 export function getCommunes(args: any): Promise<Commune[]> {

--- a/src/lib/api-insee.ts
+++ b/src/lib/api-insee.ts
@@ -12,7 +12,7 @@ export const getCommunesPrecedentes = async (code: string): Promise<CommunePrece
       'accept': 'application/json',
       'Content-Type': 'application/json',
     },
-    cache: 'force-cache',
+    next: { revalidate: 1800 },
   })
 
   if (!response.ok) {

--- a/src/lib/api-signalement.ts
+++ b/src/lib/api-signalement.ts
@@ -23,7 +23,7 @@ export function getSignalements(options?: {
   url.searchParams.append('limit', limit.toString())
   addSearchParams(url, options)
 
-  return customFetch(url, { cache: 'force-cache' })
+  return customFetch(url, { next: { revalidate: 1800 } })
 }
 
 export const getSignalementSourceId = (): string | null => {

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -19,7 +19,7 @@ const fetchOptions: RequestInit = {
   method: 'GET',
   headers: { 'content-type': 'application/json' },
   mode: 'cors',
-  cache: 'force-cache',
+  next: { revalidate: 900 }, // 15min
 }
 
 function buildTagFilter(tags?: string) {
@@ -58,11 +58,12 @@ function buildQuery(options: PostOptions = {}) {
   return computedUrl
 }
 
-export async function getPosts(options: PostOptions = {}) {
+export async function getPosts(options: PostOptions = {}, fetchInit?: RequestInit) {
   const query = buildQuery(options)
+  const opts = fetchInit ? { ...fetchOptions, ...fetchInit } : fetchOptions
 
   try {
-    const res = await fetch(query, fetchOptions)
+    const res = await fetch(query, opts)
     if (res.ok) {
       return await res.json()
     }
@@ -92,9 +93,12 @@ export async function getSinglePost(slug: string) {
   return null
 }
 
-export async function getTags() {
+export async function getTags(fetchInit?: RequestInit) {
+  const opts = fetchInit
+    ? { method: 'GET', headers: { 'content-type': 'application/json' }, mode: 'cors' as RequestMode, ...fetchInit }
+    : { method: 'GET', headers: { 'content-type': 'application/json' }, mode: 'cors' as RequestMode, next: { revalidate: 900 } }
   try {
-    const res = await fetch(`${API_URL}/tags?key=${KEY}`, { cache: 'force-cache' })
+    const res = await fetch(`${API_URL}/tags?key=${KEY}`, opts)
 
     if (res.ok) {
       const data = await res.json()


### PR DESCRIPTION
Première version de gestion de cache qui comprends:
- Gestion cache page commune
- Gestion cache home et suppression cache sur le bloc "Blog"
- Suppression du cache sur les événements et le événements pour le menu "Webinaires et formation"