### PR TITLE
fix le titre sur les pages partenaires

### DIFF
--- a/src/app/partenaires/[id]/page.tsx
+++ b/src/app/partenaires/[id]/page.tsx
@@ -8,14 +8,12 @@ import PartenaireOrganisme from '@/components/Partenaires/PartenaireOrganisme'
 import { Metadata } from 'next'
 
 interface PartenairePageprops {
-  params: { id: string }
+  id: string
 }
 
-export async function generateMetadata({
-  params,
-}: PartenairePageprops): Promise<Metadata> {
-  const { id } = await params
-  const partenaireDeLaCharte = await getOnePartenairesDeLaCharte(params.id)
+export async function generateMetadata(props : { params : Promise<PartenairePageprops> }): Promise<Metadata> {
+  const { id } = await props.params
+  const partenaireDeLaCharte = await getOnePartenairesDeLaCharte(id)
 
   return {
     title: `Partenaire - ${partenaireDeLaCharte.name}`,


### PR DESCRIPTION
Fix suite au message de Guillaume Fay :
Hello , nos pages partenaires sont HS sur le site adresse. Exemple : https://adresse.data.gouv.fr/partenaires/64ecadcef5e9efbd57bdcfe9
J'ai l'impression que la régression a été introduite par ce commit (257937ac826fe8e1fbd41cbf2f2b9d0e9b3d74b4) il y'a 3j. Vous pouvez fix?