### PR TITLE
Ajout lien flux rss geocodeur

### DIFF
--- a/public/markdown/apis/service-geocodage--intro.md
+++ b/public/markdown/apis/service-geocodage--intro.md
@@ -8,7 +8,11 @@ intro: [{attach: "la-base-adresse-nationale", filename: "service-geocodage--intr
 
 Le Service de géocodage permet d'effectuer rapidement une recherche d’adresse, mais aussi associer selon plusieurs critères des coordonnées à une adresse, un point d'intérêt ou une parcelle cadastrale.
 
+
+Vous pouvez suivre le flux RSS des évolutions du Géocodeur sur la Géoplateforme:  [Journal des évolutions du service](https://geoplateforme.github.io/tutoriels/production/changements/category/g%C3%A9ocodage/)
+
 **Le moteur de géocodage est actualisé à partir des données de la BAN deux fois par semaine.**
+
 
 
 


### PR DESCRIPTION
Ajout lien flux rss sur la page Géocodeur de la geoplateforme
Fix: #2497 

<img width="1238" height="419" alt="Capture d’écran du 2026-06-24 10-37-04" src="https://github.com/user-attachments/assets/399825f9-3831-4015-a20e-c51729a12a9d" />

