### PR TITLE
fix: page commune error when dateRevision = null

### DIFF
--- a/src/components/Commune/CommuneCertificationBar/index.tsx
+++ b/src/components/Commune/CommuneCertificationBar/index.tsx
@@ -1,50 +1,44 @@
-'use client'
+"use client";
 
-import CardWrapper from '../../CardWrapper'
-import type { ReactNode } from 'react'
-import { formatFr } from '@/lib/array'
-import { assemblageSources } from '@/lib/api-ban'
-import { BANCommune } from '@/types/api-ban.types'
-import formatNumber from '@/app/carte-base-adresse-nationale/tools/formatNumber'
-import { StyledWrapper } from './CommuneCertificationBar.styles'
-import { format, parseISO } from 'date-fns'
-import { fr } from 'date-fns/locale'
+import CardWrapper from "../../CardWrapper";
+import type { ReactNode } from "react";
+import { formatFr } from "@/lib/array";
+import { assemblageSources } from "@/lib/api-ban";
+import { BANCommune } from "@/types/api-ban.types";
+import formatNumber from "@/app/carte-base-adresse-nationale/tools/formatNumber";
+import { StyledWrapper } from "./CommuneCertificationBar.styles";
+import { format, parseISO } from "date-fns";
+import { fr } from "date-fns/locale";
 
 interface CommuneCertificationBarProps {
-  commune: BANCommune
-  lastRevisionsDetails: (string | ReactNode | null)[][] | null
-  certificationPercentage: number
-  communeHasBAL: boolean
-  banId: string | null
+  commune: BANCommune;
+  lastRevisionsDetails: (string | ReactNode | null)[][] | null;
+  certificationPercentage: number;
+  communeHasBAL: boolean;
+  banId: string | null;
 }
 
-export function CommuneCertificationBar({ commune, certificationPercentage, communeHasBAL, lastRevisionsDetails, banId }: CommuneCertificationBarProps) {
+export function CommuneCertificationBar({
+  commune,
+  certificationPercentage,
+  communeHasBAL,
+  lastRevisionsDetails,
+  banId,
+}: CommuneCertificationBarProps) {
   return (
     <StyledWrapper $certificationPercentage={certificationPercentage}>
       <CardWrapper>
         <div className="adresse-recap">
-          <div>
-            {commune.nbVoies}
-          </div>
-          <label>
-            voies, places et lieux-dits adressés
-          </label>
+          <div>{commune.nbVoies}</div>
+          <label>voies, places et lieux-dits adressés</label>
         </div>
         <div className="adresse-recap">
-          <div>
-            {commune.nbNumeros}
-          </div>
-          <label>
-            adresses
-          </label>
+          <div>{commune.nbNumeros}</div>
+          <label>adresses</label>
         </div>
         <div className="adresse-recap">
-          <div>
-            {certificationPercentage} %
-          </div>
-          <label>
-            d&apos;adresses certifiées
-          </label>
+          <div>{certificationPercentage} %</div>
+          <label>d&apos;adresses certifiées</label>
         </div>
       </CardWrapper>
       <CardWrapper>
@@ -54,8 +48,10 @@ export function CommuneCertificationBar({ commune, certificationPercentage, comm
             Mode de publication
           </label>
           <div>
-            {!communeHasBAL && 'Assemblage'}
-            {communeHasBAL && lastRevisionsDetails && lastRevisionsDetails[0][2]}
+            {!communeHasBAL && "Assemblage"}
+            {communeHasBAL &&
+              lastRevisionsDetails &&
+              lastRevisionsDetails[0][2]}
           </div>
         </div>
         <div className="publication-recap">
@@ -65,7 +61,9 @@ export function CommuneCertificationBar({ commune, certificationPercentage, comm
           </label>
           <div>
             {!communeHasBAL && formatFr(assemblageSources(commune.voies))}
-            {communeHasBAL && lastRevisionsDetails && lastRevisionsDetails[0][3]}
+            {communeHasBAL &&
+              lastRevisionsDetails &&
+              lastRevisionsDetails[0][3]}
           </div>
         </div>
         <div className="publication-recap">
@@ -74,8 +72,13 @@ export function CommuneCertificationBar({ commune, certificationPercentage, comm
             Dernière mise à jour
           </label>
           <div>
-            {!communeHasBAL && '-'}
-            {communeHasBAL && commune && format(parseISO(commune.dateRevision as string), '\'le\' dd MMMM yyyy \'à\' HH:mm', { locale: fr })}
+            {communeHasBAL && commune && commune.dateRevision
+              ? format(
+                  parseISO(commune.dateRevision as string),
+                  "'le' dd MMMM yyyy 'à' HH:mm",
+                  { locale: fr },
+                )
+              : "-"}
           </div>
         </div>
       </CardWrapper>
@@ -85,35 +88,32 @@ export function CommuneCertificationBar({ commune, certificationPercentage, comm
             <i className="ri-links-line" />
             Code INSEE
           </label>
-          <div>
-            {commune.codeCommune}
-          </div>
+          <div>{commune.codeCommune}</div>
         </div>
         <div className="publication-recap">
           <label>
             <i className="ri-signpost-line" />
-            {
-              Number(commune.codesPostaux.length) > 1
-                ? <><b>{formatNumber(commune.codesPostaux.length)}</b>&nbsp;codes Postaux</>
-                : <>{commune.codesPostaux.length || 'Aucune'} code Postal</>
-            }{' '}
+            {Number(commune.codesPostaux.length) > 1 ? (
+              <>
+                <b>{formatNumber(commune.codesPostaux.length)}</b>&nbsp;codes
+                Postaux
+              </>
+            ) : (
+              <>{commune.codesPostaux.length || "Aucune"} code Postal</>
+            )}{" "}
           </label>
-          <div>
-            {commune.codesPostaux.join(', ')}
-          </div>
+          <div>{commune.codesPostaux.join(", ")}</div>
         </div>
         <div className="publication-recap">
           <label>
             <i className="ri-key-line" />
             Identifiant BAN commune :
           </label>
-          <div>
-            {banId || '-'}
-          </div>
+          <div>{banId || "-"}</div>
         </div>
       </CardWrapper>
     </StyledWrapper>
-  )
+  );
 }
 
-export default CommuneCertificationBar
+export default CommuneCertificationBar;


### PR DESCRIPTION
## CONTEXT

Dans certain cas `commune.dateRevision` est null et cela lance une erreur sur la page
Exemple: https://adresse.data.gouv.fr/commune/39146

## RESOLUTION

Vérifier que la variable `commune.dateRevision` existe pour ne pas lancer une erreur générale sur la page