### PR TITLE
fix: bug form partenaire coverDepartement

### DIFF
--- a/src/components/PartenairesDeLaCharte/CandidacyForm/index.tsx
+++ b/src/components/PartenairesDeLaCharte/CandidacyForm/index.tsx
@@ -229,10 +229,10 @@ function CandidacyForm({ onClose, services, departements, defaultType = Partenai
               placeholder="Sélectionnez un ou plusieurs départements"
               value={formData.coverDepartement}
               options={departementsOptions}
-              onChange={(codeDepartement: string[]) => {
+              onChange={(coverDepartement: string[]) => {
                 setFormData(state => ({
                   ...state,
-                  codeDepartement,
+                  coverDepartement,
                 }))
               }}
             />


### PR DESCRIPTION
## CONTEXT

Il y avait un mini bug sur la formulaire pour devenir partenaire, on ne pouvait pas remplir les départements couvert et donc pas envoyé le formulaire