### PR TITLE
feat: add parseError in validateur

### DIFF
--- a/src/components/ValidateurBAL/ValidationErrorParse.tsx
+++ b/src/components/ValidateurBAL/ValidationErrorParse.tsx
@@ -19,7 +19,7 @@ function ValidationErrorParseReport({ report }: ValidationErrorParseReportProps)
     <Section>
       <Alert
         description={<>
-          {report.parseErrors.map(({message, row}) => (<p>{message}{row ? ` at the line ${row}` : ''}</p>))}
+          {report.parseErrors.map(({index, message, row}) => (<p key={index}>{message}{row ? ` at the line ${row}` : ''}</p>))}
         </>}
         severity="error"
         title="Le fichier n'est pas un CSV valide"

--- a/src/components/ValidateurBAL/ValidationErrorParse.tsx
+++ b/src/components/ValidateurBAL/ValidationErrorParse.tsx
@@ -1,0 +1,31 @@
+import { Alert } from '@codegouvfr/react-dsfr/Alert'
+import Section from '../Section'
+import { profiles, ValidateType, ParseFileType } from '@ban-team/validateur-bal'
+import ValidationSummary from './ValidationSummary'
+import { useMemo, useRef } from 'react'
+import { getNbRowsRemediation } from '@/utils/remediation'
+import AlertMiseEnForme from '../MiseEnForme/MiseEnFormeAlert'
+import ValidationTableError from './ValidationTableError'
+import ValidationStructureFile from './ValidationStructureFile'
+import ValidationFields from './ValidationFields'
+
+interface ValidationErrorParseReportProps {
+  report: ParseFileType
+}
+
+function ValidationErrorParseReport({ report }: ValidationErrorParseReportProps) {
+
+  return (
+    <Section>
+      <Alert
+        description={<>
+          {report.parseErrors.map(({message, row}) => (<p>{message}{row ? ` at the line ${row}` : ''}</p>))}
+        </>}
+        severity="error"
+        title="Le fichier n'est pas un CSV valide"
+      />
+    </Section>
+  )
+}
+
+export default ValidationErrorParseReport

--- a/src/components/ValidateurBAL/index.tsx
+++ b/src/components/ValidateurBAL/index.tsx
@@ -11,6 +11,7 @@ import DropZoneInput from '../DropZoneInput'
 import Alert from '@codegouvfr/react-dsfr/Alert'
 import Button from '@codegouvfr/react-dsfr/Button'
 import { useSearchParams } from 'next/navigation'
+import ValidationErrorParseReport from './ValidationErrorParse'
 
 const availableProfiles = ['1.3', '1.4', '1.5']
 
@@ -36,6 +37,7 @@ export default function ValidateurBAL() {
     try {
       setIsLoading(true)
       const report = await validate(file as any, profile ? { profile } : undefined)
+      console.log(report)
       if (report.parseOk) {
         setProfile((report as ValidateType).profile)
       }
@@ -98,7 +100,7 @@ export default function ValidateurBAL() {
         {
           isLoading
             ? <Loader />
-            : (validationReport && profile && file)
+            : validationReport ? ((validationReport.parseOk && profile && file)
                 ? (
                     <>
                       <div style={{ marginLeft: '1.5rem', display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end' }}>
@@ -115,8 +117,12 @@ export default function ValidateurBAL() {
                       </div>
                       <ValidationReport file={file} report={validationReport} profile={profile} />
                     </>
-                  )
-                : (
+                  ) : (
+                      <div>
+                        <Button iconId="fr-icon-arrow-left-line" style={{ height: 'fit-content' }} onClick={handleReset}>Retour à la sélection du fichier</Button>
+                        <ValidationErrorParseReport report={validationReport as ParseFileType} />
+                      </div>
+                  )) : (
                     <DropZoneInput
                       onChange={handleFileChange}
                       label="Déposez ou cliquez ici pour uploader votre fichier BAL à valider"

--- a/src/components/ValidateurBAL/index.tsx
+++ b/src/components/ValidateurBAL/index.tsx
@@ -37,7 +37,6 @@ export default function ValidateurBAL() {
     try {
       setIsLoading(true)
       const report = await validate(file as any, profile ? { profile } : undefined)
-      console.log(report)
       if (report.parseOk) {
         setProfile((report as ValidateType).profile)
       }


### PR DESCRIPTION
## CONTEXT

Pour le moment sur la validateur en ligne, si il y a une erreur de parsing du fichier parce que ce n'est pas un CSV valide, la page se réinitialise

-> Ajout d'une Alerte avec le détail de l'erreur de parsing (en anglais)
<img width="1403" height="829" alt="Capture d’écran 2026-07-08 à 15 58 27" src="https://github.com/user-attachments/assets/adff2f85-d257-4646-a381-0cef10c31d0d" />
